### PR TITLE
wrap creating model in new transaction

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -23,11 +23,13 @@ class Notification < ApplicationRecord
   private_constant :NotificationData
 
   def create_model
-    data = NotificationData.new(self.data)
+    transaction(requires_new: true) do
+      data = NotificationData.new(self.data)
 
-    type = data.type.lock.find_or_create_by!(data.to_hash.merge(tenant: tenant))
+      type = data.type.lock.find_or_create_by!(data.to_hash.merge(tenant: tenant))
 
-    Model.lock.find_or_create_by!(record: type, tenant: tenant)
+      Model.lock.find_or_create_by!(record: type, tenant: tenant)
+    end
   rescue ActiveRecord::RecordNotUnique
     retry
   end


### PR DESCRIPTION
as hitting constraint error will abort whole transaction
resulting in:
> ActiveRecord::StatementInvalid (PG::InFailedSqlTransaction: ERROR:  current transaction is aborted, commands ignored until end of transaction block