### PR TITLE
check pending migrations in status api

### DIFF
--- a/app/services/status_service.rb
+++ b/app/services/status_service.rb
@@ -22,6 +22,8 @@ class StatusService
   end
 
   def call
+    ActiveRecord::Migration.check_pending!
+
     Status.new(database: ActiveRecord::Base.connected?)
   end
 end


### PR DESCRIPTION
if there are pending migrations instance will be killed
and restarted, so migrations are executed again