### PR TITLE
fix bugsnag configuration

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -30,4 +30,4 @@ test:
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  bugsnag_api_key: <% ENV['BUGSNAG_API_KEY'] %>
+  bugsnag_api_key: <%= ENV['BUGSNAG_API_KEY'] %>


### PR DESCRIPTION
`bugsnag_api_key` secret was always empty