### PR TITLE
[api] option to enable token auth via ENV

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,25 @@
 require 'application_responder'
 
 class ApplicationController < ActionController::API
+  include ActionController::HttpAuthentication::Token::ControllerMethods
+
   self.responder = ApplicationResponder
 
+  before_action :authenticate
   respond_to :json
+
+  protected
+
+  def authenticate
+    authentication = Rails.application.secrets.authentication || {}.freeze
+
+    expected_token = authentication.fetch(:token) { return }
+
+    authenticate_or_request_with_http_token do |token|
+      ActiveSupport::SecurityUtils.secure_compare(
+        ::Digest::SHA256.hexdigest(token),
+        ::Digest::SHA256.hexdigest(expected_token)
+      )
+    end
+  end
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -31,3 +31,5 @@ test:
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   bugsnag_api_key: <%= ENV['BUGSNAG_API_KEY'] %>
+  authentication:
+    token: <%= ENV['ZYNC_AUTHENTICATION_TOKEN'] %>


### PR DESCRIPTION
using ZYNC_AUTHENTICATION_TOKEN environment variable
will enable Bearer token authentication