### PR TITLE
[keycloak] normalize endpoint

### DIFF
--- a/app/adapters/keycloak.rb
+++ b/app/adapters/keycloak.rb
@@ -145,15 +145,27 @@ class Keycloak
     attr_reader :uri, :client_id, :client_secret
 
     def initialize(endpoint)
+      uri, client_id, client_secret = split_uri(endpoint)
+
+      @uri = normalize_uri(uri).freeze
+      @client_id = client_id.freeze
+      @client_secret = client_secret.freeze
+    end
+
+    delegate :normalize_uri, :split_uri, to: :class
+
+    def self.normalize_uri(uri)
+      uri.normalize.merge("#{uri.path}/".tr_s('/', '/'))
+    end
+
+    def self.split_uri(endpoint)
       uri = URI(endpoint)
       client_id = uri.user
       client_secret = uri.password
 
       uri.userinfo = ''
 
-      @uri = uri.freeze
-      @client_id = client_id.freeze
-      @client_secret = client_secret.freeze
+      [ uri, client_id, client_secret ]
     end
   end
 

--- a/test/adapters/keycloak_test.rb
+++ b/test/adapters/keycloak_test.rb
@@ -11,4 +11,14 @@ class KeycloakTest < ActiveSupport::TestCase
 
     assert_kind_of URI, keycloak.endpoint
   end
+
+  test 'endpoint normalization' do
+    uri = URI('http://lvh.me:3000/auth/realm/name/')
+
+    assert_equal uri,
+                 Keycloak.new('http://id:secret@lvh.me:3000/auth/realm/name').endpoint
+
+    assert_equal uri,
+                 Keycloak.new('http://id:secret@lvh.me:3000/auth/realm/name/').endpoint
+  end
 end


### PR DESCRIPTION
so it always has a trailing slash

so the subsequent URI.join will keep the base path