### PR TITLE
[model] weaker lock to not stall notification ingestion

### DIFF
--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -8,4 +8,8 @@ class Model < ApplicationRecord
   def for_integration
     record.try(:integration_model) || self
   end
+
+  def weak_lock
+    lock!('FOR NO KEY UPDATE')
+  end
 end

--- a/app/models/update_state.rb
+++ b/app/models/update_state.rb
@@ -7,7 +7,7 @@ class UpdateState < ApplicationRecord
 
   def self.acquire_lock(model)
     transaction do
-      state = lock.find_or_create_by!(model: model.lock!)
+      state = lock.find_or_create_by!(model: model.weak_lock)
 
       yield state
     end

--- a/app/services/incoming_notification_service.rb
+++ b/app/services/incoming_notification_service.rb
@@ -7,6 +7,10 @@ class IncomingNotificationService
     freeze
   end
 
+  class << self
+    delegate :call, to: :new
+  end
+
   def call(notification)
     notification.transaction do
       model = notification.model ||= notification.create_model

--- a/test/services/incoming_notification_service_test.rb
+++ b/test/services/incoming_notification_service_test.rb
@@ -31,4 +31,44 @@ class IncomingNotificationServiceTest < ActiveSupport::TestCase
     assert @service.call(n1)
     assert @service.call(n2)
   end
+
+  class LockingTest < ActiveSupport::TestCase
+    self.use_transactional_tests = false
+
+    teardown do
+      ::Que.clear!
+    end
+
+    def test_process_locked_model
+      notification = notifications(:two)
+
+      queue = SizedQueue.new(1)
+
+      Model.connection.execute('SET SESSION statement_timeout TO 100;')
+
+      runner = Thread.new do
+        Model.connection_pool.with_connection do |connection|
+          connection.transaction do
+            connection.execute('SET SESSION statement_timeout TO 100;')
+            model = Model.find(notification.model_id)
+
+            UpdateState.acquire_lock(model) do |state|
+              queue.push state
+              queue.push model.touch
+              queue.push true
+            end
+
+          end
+        end
+      end
+      runner.abort_on_exception = true
+
+    assert_kind_of UpdateState, queue.pop
+    assert IncomingNotificationService.call(notification.dup)
+
+    ensure
+      runner.kill
+      runner.join
+    end
+  end
 end


### PR DESCRIPTION
* foreign key requires FOR NO KEY UPDATE lock and would
  not work with FOR UPDATE lock