### PR TITLE
concurrent update jobs have exponential backoff

### DIFF
--- a/app/jobs/update_job.rb
+++ b/app/jobs/update_job.rb
@@ -7,6 +7,7 @@ class UpdateJob < ApplicationJob
   queue_as :default
 
   retry_on Errno::ECONNREFUSED, wait: :exponentially_longer, attempts: 10
+  retry_on Model::LockTimeoutError, wait: :exponentially_longer, attempts: 10
 
   def initialize(*)
     super

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -2,7 +2,26 @@
 require 'test_helper'
 
 class ModelTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def test_weak_lock
+    locking_connection = Model.connection_pool.checkout
+
+    fiber = Model.stub(:connection, locking_connection) do
+      Fiber.new do
+        locking_connection.transaction do
+          Fiber.yield Model.first!.weak_lock
+        end
+      end
+    end
+
+    locked_model = fiber.resume
+    refute_equal Model.connection, locking_connection
+
+    connection = Model.connection_pool.checkout
+
+    Model.stub(:connection, connection) do
+      assert_raises Model::LockTimeoutError do
+        Model.find(locked_model.id).weak_lock
+      end
+    end
+  end
 end

--- a/test/services/incoming_notification_service_test.rb
+++ b/test/services/incoming_notification_service_test.rb
@@ -63,8 +63,11 @@ class IncomingNotificationServiceTest < ActiveSupport::TestCase
       end
       runner.abort_on_exception = true
 
-    assert_kind_of UpdateState, queue.pop
-    assert IncomingNotificationService.call(notification.dup)
+      assert_kind_of UpdateState, queue.pop
+
+      UpdateJob.stub(:perform_later, nil) do
+        assert IncomingNotificationService.call(notification.dup)
+      end
 
     ensure
       runner.kill


### PR DESCRIPTION
by not waiting for the lock but rather using exponential pushback
we can spread the load in the future and avoid waiting on database locks