### PR TITLE
[lograge] instrument net/http client

### DIFF
--- a/app/adapters/three_scale/api/instrumented_http_client.rb
+++ b/app/adapters/three_scale/api/instrumented_http_client.rb
@@ -5,6 +5,95 @@ require 'securerandom'
 # Custom HTTP Client for 3scale API client with added instrumentation.,
 class ThreeScale::API::InstrumentedHttpClient < ThreeScale::API::HttpClient
 
+  module NetHttpNotifications
+    delegate :instrument, to: 'ActiveSupport::Notifications'
+
+    def connect
+      instrument('connect.net_http', {
+          adapter: self
+      }) do
+        super
+      end
+    end
+
+    def begin_transport(req)
+      instrument('begin_transport.net_http', {
+          adapter: self, request: req
+      }) do
+        super
+      end
+    end
+
+    def end_transport(req, res)
+      instrument('end_transport.net_http', {
+          adapter: self, request: req, response: res
+      }) do
+        super
+      end
+    end
+
+    def transport_request(req)
+      payload = { adapter: self, request: req }
+      instrument('transport_request.net_http', payload) do
+        payload[:response] = super
+      end
+    end
+
+    def ssl_socket_connect(*)
+      instrument('ssl_socket_connect.net_http', {
+          adapter: self
+      }) do
+        super
+      end
+    end
+  end
+
+  module NetHttpRequestNotifications
+    delegate :instrument, to: 'ActiveSupport::Notifications'
+
+    def exec(*)
+      instrument('exec.net_http', {
+          adapter: self, request: self
+      }) do
+        super
+      end
+    end
+  end
+
+  module NetHttpResponseNotifications
+    delegate :instrument, to: 'ActiveSupport::Notifications'
+
+    def reading_body(*)
+      instrument('reading_body.net_http', {
+          adapter: self, response: self
+      }) do
+        super
+      end
+    end
+
+    module ClassMethods
+      delegate :instrument, to: 'ActiveSupport::Notifications'
+
+      def read_new(*)
+        payload = { }
+        instrument('read_new.net_http', payload) do
+          payload[:adapter] = payload[:response] = super
+        end
+      end
+
+      public :read_new
+    end
+  end
+
+  Net::HTTPResponse.prepend(NetHttpResponseNotifications)
+  Net::HTTPResponse.singleton_class.prepend(NetHttpResponseNotifications::ClassMethods)
+
+  def initialize(*)
+    super
+
+    @http.extend(NetHttpNotifications)
+  end
+
   def get(path, params: nil)
     req = build_request(Net::HTTP::Get, path, params)
     parse request(req, params: params)
@@ -49,7 +138,7 @@ class ThreeScale::API::InstrumentedHttpClient < ThreeScale::API::HttpClient
 
   def build_request(type, path, params)
     uri = format_path_n_query(path, params)
-    type.new(uri, headers)
+    type.new(uri, headers).extend(NetHttpRequestNotifications)
   end
 
   def request(req, body = nil, params: )

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -19,4 +19,7 @@ if Rails.application.config.lograge.enabled
 
   require 'lograge/http_subscriber'
   Lograge::HTTPSubscriber.attach_to :three_scale_api_client
+
+  require 'lograge/net_http_subscriber'
+  Lograge::NetHttpSubscriber.attach_to :net_http
 end

--- a/lib/lograge/net_http_subscriber.rb
+++ b/lib/lograge/net_http_subscriber.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'lograge/subscriber_base'
+
+module Lograge
+  # Log Subscriber for OIDC integrations. Consumes Client create/update/remove events.
+
+  class NetHttpSubscriber < ActiveSupport::LogSubscriber
+    include Lograge::SubscriberBase
+
+    log_event :connect
+    log_event :transport_request
+    log_event :ssl_socket_connect
+    log_event :exec
+    log_event :reading_body
+    log_event :begin_transport
+    log_event :end_transport
+    log_event :read_new
+
+    protected
+
+    def initial_data(payload)
+
+      data = extract_payload(payload.fetch(:adapter))
+
+      data
+          .merge(extract_payload(payload[:request]))
+          .merge(extract_payload(payload[:response]))
+    end
+
+    def extract_payload(adapter)
+      case adapter
+        when Net::HTTP
+          {
+              adapter: 'Net::HTTP',
+              address: adapter.address, port: adapter.port,
+              ssl: adapter.use_ssl?, proxy: adapter.proxy?
+          }
+        when Net::HTTPGenericRequest
+          {
+              adapter: 'Net::HTTP',
+              uri: adapter.uri, path: adapter.path
+
+          }
+        when Net::HTTPResponse
+          {
+              adapter: 'Net::HTTP',
+              uri: adapter.uri, message: adapter.message, code: adapter.code
+
+          }
+        when nil then {}
+        else
+          raise "can't extract data from #{adapter.class}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
instrument net/http and emit messages like:

```
{"adapter":"Net::HTTP","address":"provider-admin.3scale.net.dev","port":3000,"ssl":false,"proxy":false,"action":"connect","duration":1.79}
{"adapter":"Net::HTTP","address":"provider-admin.3scale.net.dev","port":3000,"ssl":false,"proxy":false,"uri":null,"path":"/admin/api/applications/find.json?application_id=5","action":"begin_transport","duration":0.03}
{"adapter":"Net::HTTP","uri":null,"path":"/admin/api/applications/find.json?application_id=5","action":"exec","duration":0.09}
{"adapter":"Net::HTTP","uri":null,"message":"OK","code":"200","action":"read_new","duration":172.17}
{"adapter":"Net::HTTP","uri":null,"message":"OK","code":"200","action":"reading_body","duration":0.27}
{"adapter":"Net::HTTP","address":"provider-admin.3scale.net.dev","port":3000,"ssl":false,"proxy":false,"uri":null,"path":"/admin/api/applications/find.json?application_id=5","message":"OK","code":"200","action":"end_transport","duration":0.06}
{"adapter":"Net::HTTP","address":"provider-admin.3scale.net.dev","port":3000,"ssl":false,"proxy":false,"uri":null,"path":"/admin/api/applications/find.json?application_id=5","message":"OK","code":"200","action":"transport_request","duration":173.56}
```

/cc @orimarti 