### PR TITLE
[prometheus] improve prometheus metrics

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -15,3 +15,5 @@ prometheus.register(retried_job_stats)
 pending_job_stats = Prometheus::JobStats.new(:pending_jobs, 'Que Jobs that should be already running')
 pending_job_stats.filter('run_at < now()')
 prometheus.register(pending_job_stats)
+
+require 'prometheus/active_job_subscriber'

--- a/lib/prometheus/active_job_subscriber.rb
+++ b/lib/prometheus/active_job_subscriber.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Prometheus
+
+  ## ActiveJob Subscriber to record Prometheus metrics.
+  ## Those metrics are per process, so they have to be aggregated by Prometheus.
+  class ActiveJobSubscriber < ActiveSupport::Subscriber
+
+    prometheus = Prometheus::Client.registry or raise 'Missing Prometheus client registry'
+
+    metrics = {
+        retried_jobs: prometheus.counter(:job_retries, 'A number of Jobs retried'),
+        failed_jobs: prometheus.counter(:failed_jobs, 'A number of Jobs errored'),
+        performed_jobs: prometheus.counter(:performed_jobs, 'A number of Jobs performed'),
+        enqueued_jobs: prometheus.counter(:enqueued_jobs, 'A number of Jobs enqueued'),
+        histogram: prometheus.histogram(:jobs_histogram, 'A histogram of Jobs perform times'),
+        summary: prometheus.summary(:jobs_summary, 'A summary of Jobs perform times'),
+    }
+    METRICS = OpenStruct.new(metrics).freeze
+
+    def initialize
+      super
+      @metrics = METRICS
+    end
+
+    def enqueue(event)
+      payload = event.payload
+      labels = extract_labels(payload)
+
+      if payload.fetch(:job).executions == 0
+        enqueued_jobs.increment(labels)
+      else
+        retried_jobs.increment(labels)
+      end
+    end
+
+    alias enqueue_at enqueue
+
+    def perform(event)
+      payload = event.payload
+      labels = extract_labels(payload)
+
+      observe_perform(payload, labels)
+      observe_duration(event, labels)
+    end
+
+    private
+
+    def observe_duration(event, labels)
+      duration = event.duration
+
+      histogram.observe(labels, duration)
+      summary.observe(labels, duration)
+    end
+
+    def observe_perform(payload, labels)
+      ex = payload[:exception_object]
+
+      if ex
+        # not measuring failed job duration, but we could
+        failed_jobs.increment(labels)
+      else
+        performed_jobs.increment(labels)
+      end
+    end
+
+    def extract_labels(payload)
+      {
+          adapter: payload.fetch(:adapter).class.name.demodulize.remove('Adapter'),
+          job_name: payload.fetch(:job).class.name
+      }
+    end
+
+    delegate :performed_jobs, :enqueued_jobs, :retried_jobs, :histogram, :summary, :failed_jobs,
+             to: :@metrics
+
+    attach_to :active_job
+  end
+end


### PR DESCRIPTION
more metrics about processed jobs
those new  are runtime only, so will have to be aggregated by prometheus
the previous ones were from database, so all nodes would give same results

```
# TYPE scheduled_jobs gauge
# HELP scheduled_jobs Que Jobs to be executed
scheduled_jobs{job="UpdateJob"} 4
# TYPE retried_jobs gauge
# HELP retried_jobs Que Jobs to retried
retried_jobs{job="UpdateJob"} 4
# TYPE pending_jobs gauge
# HELP pending_jobs Que Jobs that should be already running
# TYPE job_retries counter
# HELP job_retries A number of Jobs retried
job_retries{adapter="Que",job_name="UpdateJob"} 6.0
# TYPE failed_jobs counter
# HELP failed_jobs A number of Jobs errored
failed_jobs{adapter="Que",job_name="UpdateJob"} 6.0
# TYPE performed_jobs counter
# HELP performed_jobs A number of Jobs performed
performed_jobs{adapter="Que",job_name="UpdateJob"} 4.0
performed_jobs{adapter="Que",job_name="ProcessEntryJob"} 4.0
# TYPE enqueued_jobs counter
# HELP enqueued_jobs A number of Jobs enqueued
enqueued_jobs{adapter="Que",job_name="UpdateJob"} 10.0
enqueued_jobs{adapter="Que",job_name="ProcessEntryJob"} 4.0
# TYPE jobs_histogram histogram
# HELP jobs_histogram A histogram of Jobs perform times
jobs_histogram_bucket{adapter="Que",job_name="UpdateJob",le="0.005"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="UpdateJob",le="0.01"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="UpdateJob",le="0.025"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="UpdateJob",le="0.05"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="UpdateJob",le="0.1"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="UpdateJob",le="0.25"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="UpdateJob",le="0.5"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="UpdateJob",le="1"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="UpdateJob",le="2.5"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="UpdateJob",le="5"} 1.0
jobs_histogram_bucket{adapter="Que",job_name="UpdateJob",le="10"} 1.0
jobs_histogram_bucket{adapter="Que",job_name="UpdateJob",le="+Inf"} 10.0
jobs_histogram_sum{adapter="Que",job_name="UpdateJob"} 4626.851000000001
jobs_histogram_count{adapter="Que",job_name="UpdateJob"} 10.0
jobs_histogram_bucket{adapter="Que",job_name="ProcessEntryJob",le="0.005"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="ProcessEntryJob",le="0.01"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="ProcessEntryJob",le="0.025"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="ProcessEntryJob",le="0.05"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="ProcessEntryJob",le="0.1"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="ProcessEntryJob",le="0.25"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="ProcessEntryJob",le="0.5"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="ProcessEntryJob",le="1"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="ProcessEntryJob",le="2.5"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="ProcessEntryJob",le="5"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="ProcessEntryJob",le="10"} 0.0
jobs_histogram_bucket{adapter="Que",job_name="ProcessEntryJob",le="+Inf"} 4.0
jobs_histogram_sum{adapter="Que",job_name="ProcessEntryJob"} 1263.579
jobs_histogram_count{adapter="Que",job_name="ProcessEntryJob"} 4.0
# TYPE jobs_summary summary
# HELP jobs_summary A summary of Jobs perform times
jobs_summary{adapter="Que",job_name="UpdateJob",quantile="0.5"} 113.348
jobs_summary{adapter="Que",job_name="UpdateJob",quantile="0.9"} 171.259
jobs_summary{adapter="Que",job_name="UpdateJob",quantile="0.99"} 171.259
jobs_summary_sum{adapter="Que",job_name="UpdateJob"} 4626.851000000001
jobs_summary_count{adapter="Que",job_name="UpdateJob"} 10
jobs_summary{adapter="Que",job_name="ProcessEntryJob",quantile="0.5"} 18.095
jobs_summary{adapter="Que",job_name="ProcessEntryJob",quantile="0.9"} 46.349000000000004
jobs_summary{adapter="Que",job_name="ProcessEntryJob",quantile="0.99"} 46.349000000000004
jobs_summary_sum{adapter="Que",job_name="ProcessEntryJob"} 1263.579
jobs_summary_count{adapter="Que",job_name="ProcessEntryJob"} 4
```