### PR TITLE
[zync] rename prometheus metrics

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -3,16 +3,16 @@ require 'prometheus/job_stats'
 
 prometheus = Prometheus::Client.registry
 
-scheduled_job_stats = Prometheus::JobStats.new(:scheduled_jobs, 'Que Jobs to be executed')
+scheduled_job_stats = Prometheus::JobStats.new(:zync_scheduled_jobs, 'Que Jobs to be executed')
 scheduled_job_stats
 prometheus.register(scheduled_job_stats)
 
-retried_job_stats = Prometheus::JobStats.new(:retried_jobs, 'Que Jobs to retried')
+retried_job_stats = Prometheus::JobStats.new(:zync_retried_jobs, 'Que Jobs to retried')
 retried_job_stats.filter('retries > 0')
 prometheus.register(retried_job_stats)
 
 
-pending_job_stats = Prometheus::JobStats.new(:pending_jobs, 'Que Jobs that should be already running')
+pending_job_stats = Prometheus::JobStats.new(:zync_pending_jobs, 'Que Jobs that should be already running')
 pending_job_stats.filter('run_at < now()')
 prometheus.register(pending_job_stats)
 

--- a/lib/prometheus/active_job_subscriber.rb
+++ b/lib/prometheus/active_job_subscriber.rb
@@ -9,12 +9,12 @@ module Prometheus
     prometheus = Prometheus::Client.registry or raise 'Missing Prometheus client registry'
 
     metrics = {
-        retried_jobs: prometheus.counter(:job_retries, 'A number of Jobs retried'),
-        failed_jobs: prometheus.counter(:failed_jobs, 'A number of Jobs errored'),
-        performed_jobs: prometheus.counter(:performed_jobs, 'A number of Jobs performed'),
-        enqueued_jobs: prometheus.counter(:enqueued_jobs, 'A number of Jobs enqueued'),
-        histogram: prometheus.histogram(:jobs_histogram, 'A histogram of Jobs perform times'),
-        summary: prometheus.summary(:jobs_summary, 'A summary of Jobs perform times'),
+        retried_jobs: prometheus.counter(:zync_job_retries, 'A number of Jobs retried'),
+        failed_jobs: prometheus.counter(:zync_failed_jobs, 'A number of Jobs errored'),
+        performed_jobs: prometheus.counter(:zync_performed_jobs, 'A number of Jobs performed'),
+        enqueued_jobs: prometheus.counter(:zync_enqueued_jobs, 'A number of Jobs enqueued'),
+        histogram: prometheus.histogram(:zync_jobs_histogram, 'A histogram of Jobs perform times'),
+        summary: prometheus.summary(:zync_jobs_summary, 'A summary of Jobs perform times'),
     }
     METRICS = OpenStruct.new(metrics).freeze
 


### PR DESCRIPTION
* all metrics should be prefixed with the project name
see https://github.com/3scale/zync/pull/78#issuecomment-346027324