### PR TITLE
Send zync token to authenticate to System

### DIFF
--- a/app/adapters/keycloak.rb
+++ b/app/adapters/keycloak.rb
@@ -89,7 +89,7 @@ class Keycloak
     end
 
     def enabled?
-      state ? state == 'live' : enabled
+      enabled
     end
   end
 

--- a/app/adapters/three_scale/api/instrumented_http_client.rb
+++ b/app/adapters/three_scale/api/instrumented_http_client.rb
@@ -58,10 +58,10 @@ class ThreeScale::API::InstrumentedHttpClient < ThreeScale::API::HttpClient
   protected
 
   def headers
-    super.merge(extra_headers)
+    super.merge(self.class.extra_headers)
   end
 
-  def extra_headers
+  def self.extra_headers
     { 'X-Request-Id' => SecureRandom.uuid, 'X-Zync-Token' => Rails.application.secrets.authentication[:token] }.compact
   end
 

--- a/app/adapters/three_scale/api/instrumented_http_client.rb
+++ b/app/adapters/three_scale/api/instrumented_http_client.rb
@@ -58,7 +58,11 @@ class ThreeScale::API::InstrumentedHttpClient < ThreeScale::API::HttpClient
   protected
 
   def headers
-    super.merge('X-Request-Id' => SecureRandom.uuid)
+    super.merge(extra_headers)
+  end
+
+  def extra_headers
+    { 'X-Request-Id' => SecureRandom.uuid, 'X-Zync-Token' => Rails.application.secrets.authentication[:token] }.compact
   end
 
   def build_request(type, path, params)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,9 +12,9 @@ class ApplicationController < ActionController::API
   protected
 
   def authenticate
-    authentication = Rails.application.secrets.authentication || {}.freeze
+    expected_token = Rails.application.secrets.authentication[:token].presence
 
-    expected_token = authentication.fetch(:token) { return }
+    return unless expected_token
 
     authenticate_or_request_with_http_token do |token|
       ActiveSupport::SecurityUtils.secure_compare(

--- a/app/services/integration/keycloak_service.rb
+++ b/app/services/integration/keycloak_service.rb
@@ -65,7 +65,7 @@ class Integration::KeycloakService
 
   def client_params(data)
     params = ActionController::Parameters.new(data)
-    params.permit(:client_id, :client_secret, :redirect_url, :state, :name, :description)
+    params.permit(:client_id, :client_secret, :redirect_url, :state, :enabled, :name, :description)
   end
 
   def remove(client)

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -16,6 +16,9 @@
 #   api_key: a1B2c3D4e5F6
 
 # Environmental secrets are only available for that specific environment.
+shared:
+  authentication:
+    token: <%= ENV['ZYNC_AUTHENTICATION_TOKEN'] %>
 
 development:
   secret_key_base: 7236814be2201361bc2ce32c3bb4e425ace58925f9967ed496f966e0fc835749ee30ce43b31a1a193f48c56a5c3eb7dbb05183b0415b829960f42f7175c0d4f4
@@ -31,5 +34,4 @@ test:
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   bugsnag_api_key: <%= ENV['BUGSNAG_API_KEY'] %>
-  authentication:
-    token: <%= ENV['ZYNC_AUTHENTICATION_TOKEN'] %>
+

--- a/test/adapters/three_scale/api/instrumented_http_client_test.rb
+++ b/test/adapters/three_scale/api/instrumented_http_client_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class ThreeScale::API::InstrumentedHttpClienTest < ActiveSupport::TestCase
+
+  test 'new' do
+    uri = 'http://system.local'
+    http_client = ThreeScale::API::InstrumentedHttpClient.new(endpoint: uri, provider_key: 'provider-key')
+
+    Rails.application.secrets.stub(:authentication, {token: 'zync-token'}) do
+      stub_request(:any, 'http://system.local/all.json').to_return(status: 200, body: "", headers: {})
+      http_client.put('/all')
+      assert_requested(:put, "http://system.local/all.json", headers: {'X-Zync-Token' => 'zync-token'})
+    end
+  end
+
+end


### PR DESCRIPTION
Mutual authentication with system.
It uses the same token that System workers to authenticate with Zync.
Zync will query system with this token in the header to identify itself

Ideas could be to use BasicAuth but we would need to modify System code base.
Can be improved later I think