### PR TITLE
By default enable all OAuth 2.0 flows on the Keycloak client

### DIFF
--- a/app/adapters/keycloak.rb
+++ b/app/adapters/keycloak.rb
@@ -75,6 +75,10 @@ class Keycloak
         secret: client_secret,
         redirectUris: [ redirect_url ].compact,
         attributes: { '3scale' => true },
+        standardFlowEnabled: true,
+        implicitFlowEnabled: true,
+        serviceAccountsEnabled: true,
+        directAccessGrantsEnabled: true,
         enabled: enabled?,
       }.to_json
     end


### PR DESCRIPTION
By default, when a client is created in Keycloak (on application create in 3scale), only the Authorization Code flow (`standardFlow`) is enabled. I think Zync may as well enable all flows at once for more flexibility.
Ideally this should be configurable (see [THREESCALE-774](https://issues.jboss.org/browse/THREESCALE-774)), but having all enabled seems to be an acceptable workaround.