### PR TITLE
Add support for direct access grants

### DIFF
--- a/app/adapters/keycloak.rb
+++ b/app/adapters/keycloak.rb
@@ -76,6 +76,7 @@ class Keycloak
         redirectUris: [ redirect_url ].compact,
         attributes: { '3scale' => true },
         enabled: enabled?,
+        directAccessGrantsEnabled: directAccess?,
       }.to_json
     end
 
@@ -90,6 +91,10 @@ class Keycloak
 
     def enabled?
       enabled
+    end
+
+    def directAccess?
+      ENV['DIRECT_ACCESS_ENABLED'] == 'true'
     end
   end
 


### PR DESCRIPTION
We have a use case where we'd like for Direct Access Grants to be enabled on clients as they're created in RHSSO. This may not be desirable by all, so this also must be enabled via an ENV var. 

This resolves [THREESCALE-1342](https://issues.jboss.org/browse/THREESCALE-1342)