### PR TITLE
[keycloak] ability to configure extra client attributes

### DIFF
--- a/app/adapters/keycloak.rb
+++ b/app/adapters/keycloak.rb
@@ -67,16 +67,19 @@ class Keycloak
     alias_attribute :client_id, :id
     alias_attribute :client_secret, :secret
 
-    def read
+    delegate :to_json, to: :attributes
+    alias read to_json
+
+    def attributes
       {
-        name: name,
-        description: description,
-        clientId: id,
-        secret: client_secret,
-        redirectUris: [ redirect_url ].compact,
-        attributes: { '3scale' => true },
-        enabled: enabled?,
-      }.to_json
+          name: name,
+          description: description,
+          clientId: id,
+          secret: client_secret,
+          redirectUris: [ redirect_url ].compact,
+          attributes: { '3scale' => true },
+          enabled: enabled?,
+      }.merge(self.class.attributes)
     end
 
     # This method smells of :reek:UncommunicativeMethodName but it comes from Keycloak
@@ -90,6 +93,10 @@ class Keycloak
 
     def enabled?
       enabled
+    end
+
+    def self.attributes
+      Rails.application.config.x.keycloak.dig(:attributes) || Hash.new
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,5 +64,7 @@ module Zync
     initializer 'message_bus.middleware', after: 'message_bus.configure_init' do
       config.middleware.delete(ActionDispatch::Flash) # remove it after message bus loaded
     end
+
+    config.x.keycloak = config_for(:keycloak) || Hash.new
   end
 end

--- a/config/keycloak.yml
+++ b/config/keycloak.yml
@@ -1,0 +1,13 @@
+example:
+  attributes:
+    # see other properties in https://www.keycloak.org/docs-api/3.4/javadocs/org/keycloak/representations/idm/ClientTemplateRepresentation.html
+    standardFlowEnabled: true
+    implicitFlowEnabled: false
+    serviceAccountsEnabled: true
+    directAccessGrantsEnabled: true
+
+development:
+
+production:
+
+test:

--- a/test/adapters/keycloak_test.rb
+++ b/test/adapters/keycloak_test.rb
@@ -45,4 +45,30 @@ class KeycloakTest < ActiveSupport::TestCase
       keycloak.test
     end
   end
+
+  test 'using configuration' do
+    config = {
+        attributes: {
+            serviceAccountsEnabled: true
+        }
+    }
+
+    Rails.application.config.x.stub(:keycloak, config) do
+      client = Keycloak::Client.new(name: 'foo')
+
+      assert_includes client.attributes, :serviceAccountsEnabled
+    end
+  end
+
+  test 'client attributes' do
+    client = Keycloak::Client.new(name: 'name')
+
+    assert_includes client.attributes, :name
+  end
+
+  test 'client serialization' do
+    client = Keycloak::Client.new(name: 'name')
+
+    assert_equal client.attributes.to_json, client.to_json
+  end
 end


### PR DESCRIPTION
Define yaml config with extra attributes sent to keycloak. This allows anyone to pass own yaml config and configure extra payload sent to Keycloak.

closes #91
closes #89