### PR TITLE
[rake] boot:db task

### DIFF
--- a/lib/tasks/boot.rake
+++ b/lib/tasks/boot.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :boot do
+  desc "Return failure in case database is not ready"
+  task db: :environment do
+    begin
+      ApplicationRecord.retrieve_connection
+    rescue => error
+      warn error
+      exit ApplicationRecord.connected?
+    end
+  end
+end


### PR DESCRIPTION
Exits with error code 1 when database is not reachable.