### PR TITLE
Synchronize changes with the same client_id on the same service [THREESCALE-1346]

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class Client < ApplicationRecord
+  belongs_to :service
+  belongs_to :tenant
+
+  validates :client_id, presence: true, uniqueness: { scope: :service_id }
+
+  attr_readonly :client_id, :service_id, :tenant_id
+
+  def self.for_service(service)
+    where(service: service, tenant: service.tenant)
+  end
+
+  def integration_model
+    Model.find_by(record: service)
+  end
+end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -12,6 +12,14 @@ class Model < ApplicationRecord
   # Error raised when weak lock can't be acquired.
   class LockTimeoutError < StandardError; end
 
+  def self.create_record!(tenant)
+    retry_record_not_unique do
+      record = yield
+
+      self.find_or_create_by!(record: record, tenant: tenant)
+    end
+  end
+
   def weak_lock
     lock!('FOR NO KEY UPDATE NOWAIT')
   rescue ActiveRecord::StatementInvalid => error

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -9,6 +9,10 @@ class Model < ApplicationRecord
     record.try(:integration_model) || self
   end
 
+  def weak_record
+    record_type.constantize.new(id: record_id)
+  end
+
   # Error raised when weak lock can't be acquired.
   class LockTimeoutError < StandardError; end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -36,10 +36,8 @@ class Notification < ApplicationRecord
     type = data.type
     attributes = data.to_hash.merge(tenant: tenant)
 
-    retry_record_not_unique do
-      record = type.find_or_create_by!(attributes)
-
-      Model.find_or_create_by!(record: record, tenant: tenant)
+    Model.create_record!(tenant) do
+      type.find_or_create_by!(attributes)
     end
   end
 end

--- a/app/services/fetch_service.rb
+++ b/app/services/fetch_service.rb
@@ -26,6 +26,8 @@ class FetchService
       fetch_service(model)
     when Application
       fetch_application(model)
+    when Client
+      fetch_client(model)
     when Proxy
       fetch_proxy(model)
     else
@@ -63,10 +65,23 @@ class FetchService
     build_entry(model, data: application)
   end
 
+  def fetch_client(model)
+    client = build_client(model.tenant)
+
+    begin
+      application = client.find_application(application_id: model.record.client_id)
+        # right now the client raises runtime error, but rather should return a result
+    rescue RuntimeError
+      application = nil # 404'd
+    end
+
+    build_entry(model, data: application)
+  end
+
   def build_entry(model, **attributes)
     Entry.for_model(model).tap do |entry|
       entry.assign_attributes attributes
-      Rails.logger.debug "[FetchService] got Entry: #{entry.attributes.compact}"
+      Rails.logger.debug "[FetchService] got Entry (#{model.record.class}): #{entry.attributes.compact}"
     end
   end
 end

--- a/db/migrate/20181019101631_create_clients.rb
+++ b/db/migrate/20181019101631_create_clients.rb
@@ -1,0 +1,13 @@
+class CreateClients < ActiveRecord::Migration[5.2]
+  def change
+    create_table :clients do |t|
+      t.references :service, foreign_key: true, null: false
+      t.references :tenant, foreign_key: true, null: false
+
+      t.string :client_id, null: false
+      t.timestamps
+    end
+
+    add_index :clients, [ :client_id, :service_id ], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3,6 +3,7 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
@@ -21,8 +22,6 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
-SET search_path = public, pg_catalog;
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -31,7 +30,7 @@ SET default_with_oids = false;
 -- Name: applications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE applications (
+CREATE TABLE public.applications (
     id bigint NOT NULL,
     tenant_id bigint NOT NULL,
     service_id bigint NOT NULL,
@@ -44,7 +43,7 @@ CREATE TABLE applications (
 -- Name: applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE applications_id_seq
+CREATE SEQUENCE public.applications_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -56,14 +55,14 @@ CREATE SEQUENCE applications_id_seq
 -- Name: applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE applications_id_seq OWNED BY applications.id;
+ALTER SEQUENCE public.applications_id_seq OWNED BY public.applications.id;
 
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ar_internal_metadata (
+CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -72,10 +71,43 @@ CREATE TABLE ar_internal_metadata (
 
 
 --
+-- Name: clients; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.clients (
+    id bigint NOT NULL,
+    service_id bigint NOT NULL,
+    tenant_id bigint NOT NULL,
+    client_id character varying NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: clients_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.clients_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: clients_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.clients_id_seq OWNED BY public.clients.id;
+
+
+--
 -- Name: entries; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE entries (
+CREATE TABLE public.entries (
     id bigint NOT NULL,
     data jsonb,
     tenant_id bigint NOT NULL,
@@ -89,7 +121,7 @@ CREATE TABLE entries (
 -- Name: entries_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE entries_id_seq
+CREATE SEQUENCE public.entries_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -101,14 +133,14 @@ CREATE SEQUENCE entries_id_seq
 -- Name: entries_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE entries_id_seq OWNED BY entries.id;
+ALTER SEQUENCE public.entries_id_seq OWNED BY public.entries.id;
 
 
 --
 -- Name: integration_states; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE integration_states (
+CREATE TABLE public.integration_states (
     id bigint NOT NULL,
     started_at timestamp without time zone,
     finished_at timestamp without time zone,
@@ -125,7 +157,7 @@ CREATE TABLE integration_states (
 -- Name: integration_states_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE integration_states_id_seq
+CREATE SEQUENCE public.integration_states_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -137,14 +169,14 @@ CREATE SEQUENCE integration_states_id_seq
 -- Name: integration_states_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE integration_states_id_seq OWNED BY integration_states.id;
+ALTER SEQUENCE public.integration_states_id_seq OWNED BY public.integration_states.id;
 
 
 --
 -- Name: integrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE integrations (
+CREATE TABLE public.integrations (
     id bigint NOT NULL,
     configuration jsonb,
     type character varying NOT NULL,
@@ -159,7 +191,7 @@ CREATE TABLE integrations (
 -- Name: integrations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE integrations_id_seq
+CREATE SEQUENCE public.integrations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -171,14 +203,14 @@ CREATE SEQUENCE integrations_id_seq
 -- Name: integrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE integrations_id_seq OWNED BY integrations.id;
+ALTER SEQUENCE public.integrations_id_seq OWNED BY public.integrations.id;
 
 
 --
 -- Name: message_bus; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE message_bus (
+CREATE TABLE public.message_bus (
     id bigint NOT NULL,
     channel text NOT NULL,
     value text NOT NULL,
@@ -191,7 +223,7 @@ CREATE TABLE message_bus (
 -- Name: message_bus_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE message_bus_id_seq
+CREATE SEQUENCE public.message_bus_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -203,14 +235,14 @@ CREATE SEQUENCE message_bus_id_seq
 -- Name: message_bus_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE message_bus_id_seq OWNED BY message_bus.id;
+ALTER SEQUENCE public.message_bus_id_seq OWNED BY public.message_bus.id;
 
 
 --
 -- Name: metrics; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE metrics (
+CREATE TABLE public.metrics (
     id bigint NOT NULL,
     service_id bigint NOT NULL,
     tenant_id bigint NOT NULL,
@@ -223,7 +255,7 @@ CREATE TABLE metrics (
 -- Name: metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE metrics_id_seq
+CREATE SEQUENCE public.metrics_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -235,14 +267,14 @@ CREATE SEQUENCE metrics_id_seq
 -- Name: metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE metrics_id_seq OWNED BY metrics.id;
+ALTER SEQUENCE public.metrics_id_seq OWNED BY public.metrics.id;
 
 
 --
 -- Name: models; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE models (
+CREATE TABLE public.models (
     id bigint NOT NULL,
     tenant_id bigint NOT NULL,
     record_type character varying,
@@ -256,7 +288,7 @@ CREATE TABLE models (
 -- Name: models_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE models_id_seq
+CREATE SEQUENCE public.models_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -268,14 +300,14 @@ CREATE SEQUENCE models_id_seq
 -- Name: models_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE models_id_seq OWNED BY models.id;
+ALTER SEQUENCE public.models_id_seq OWNED BY public.models.id;
 
 
 --
 -- Name: notifications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE notifications (
+CREATE TABLE public.notifications (
     id bigint NOT NULL,
     model_id bigint NOT NULL,
     data jsonb NOT NULL,
@@ -289,7 +321,7 @@ CREATE TABLE notifications (
 -- Name: notifications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE notifications_id_seq
+CREATE SEQUENCE public.notifications_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -301,14 +333,14 @@ CREATE SEQUENCE notifications_id_seq
 -- Name: notifications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE notifications_id_seq OWNED BY notifications.id;
+ALTER SEQUENCE public.notifications_id_seq OWNED BY public.notifications.id;
 
 
 --
 -- Name: proxies; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE proxies (
+CREATE TABLE public.proxies (
     id bigint NOT NULL,
     tenant_id bigint NOT NULL,
     service_id bigint NOT NULL,
@@ -321,7 +353,7 @@ CREATE TABLE proxies (
 -- Name: proxies_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE proxies_id_seq
+CREATE SEQUENCE public.proxies_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -333,14 +365,14 @@ CREATE SEQUENCE proxies_id_seq
 -- Name: proxies_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE proxies_id_seq OWNED BY proxies.id;
+ALTER SEQUENCE public.proxies_id_seq OWNED BY public.proxies.id;
 
 
 --
 -- Name: que_jobs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE que_jobs (
+CREATE TABLE public.que_jobs (
     priority smallint DEFAULT 100 NOT NULL,
     run_at timestamp with time zone DEFAULT now() NOT NULL,
     job_id bigint NOT NULL,
@@ -356,14 +388,14 @@ CREATE TABLE que_jobs (
 -- Name: TABLE que_jobs; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON TABLE que_jobs IS '3';
+COMMENT ON TABLE public.que_jobs IS '3';
 
 
 --
 -- Name: que_jobs_job_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE que_jobs_job_id_seq
+CREATE SEQUENCE public.que_jobs_job_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -375,14 +407,14 @@ CREATE SEQUENCE que_jobs_job_id_seq
 -- Name: que_jobs_job_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE que_jobs_job_id_seq OWNED BY que_jobs.job_id;
+ALTER SEQUENCE public.que_jobs_job_id_seq OWNED BY public.que_jobs.job_id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schema_migrations (
+CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
 
@@ -391,7 +423,7 @@ CREATE TABLE schema_migrations (
 -- Name: services; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE services (
+CREATE TABLE public.services (
     id bigint NOT NULL,
     tenant_id bigint NOT NULL,
     created_at timestamp without time zone NOT NULL,
@@ -403,7 +435,7 @@ CREATE TABLE services (
 -- Name: services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE services_id_seq
+CREATE SEQUENCE public.services_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -415,14 +447,14 @@ CREATE SEQUENCE services_id_seq
 -- Name: services_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE services_id_seq OWNED BY services.id;
+ALTER SEQUENCE public.services_id_seq OWNED BY public.services.id;
 
 
 --
 -- Name: tenants; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE tenants (
+CREATE TABLE public.tenants (
     id bigint NOT NULL,
     endpoint character varying NOT NULL,
     access_token character varying NOT NULL,
@@ -435,7 +467,7 @@ CREATE TABLE tenants (
 -- Name: tenants_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE tenants_id_seq
+CREATE SEQUENCE public.tenants_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -447,14 +479,14 @@ CREATE SEQUENCE tenants_id_seq
 -- Name: tenants_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE tenants_id_seq OWNED BY tenants.id;
+ALTER SEQUENCE public.tenants_id_seq OWNED BY public.tenants.id;
 
 
 --
 -- Name: update_states; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE update_states (
+CREATE TABLE public.update_states (
     id bigint NOT NULL,
     started_at timestamp without time zone,
     finished_at timestamp without time zone,
@@ -469,7 +501,7 @@ CREATE TABLE update_states (
 -- Name: update_states_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE update_states_id_seq
+CREATE SEQUENCE public.update_states_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -481,14 +513,14 @@ CREATE SEQUENCE update_states_id_seq
 -- Name: update_states_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE update_states_id_seq OWNED BY update_states.id;
+ALTER SEQUENCE public.update_states_id_seq OWNED BY public.update_states.id;
 
 
 --
 -- Name: usage_limits; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE usage_limits (
+CREATE TABLE public.usage_limits (
     id bigint NOT NULL,
     metric_id bigint NOT NULL,
     plan_id integer NOT NULL,
@@ -502,7 +534,7 @@ CREATE TABLE usage_limits (
 -- Name: usage_limits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE usage_limits_id_seq
+CREATE SEQUENCE public.usage_limits_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -514,112 +546,119 @@ CREATE SEQUENCE usage_limits_id_seq
 -- Name: usage_limits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE usage_limits_id_seq OWNED BY usage_limits.id;
+ALTER SEQUENCE public.usage_limits_id_seq OWNED BY public.usage_limits.id;
 
 
 --
 -- Name: applications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY applications ALTER COLUMN id SET DEFAULT nextval('applications_id_seq'::regclass);
+ALTER TABLE ONLY public.applications ALTER COLUMN id SET DEFAULT nextval('public.applications_id_seq'::regclass);
+
+
+--
+-- Name: clients id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.clients ALTER COLUMN id SET DEFAULT nextval('public.clients_id_seq'::regclass);
 
 
 --
 -- Name: entries id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY entries ALTER COLUMN id SET DEFAULT nextval('entries_id_seq'::regclass);
+ALTER TABLE ONLY public.entries ALTER COLUMN id SET DEFAULT nextval('public.entries_id_seq'::regclass);
 
 
 --
 -- Name: integration_states id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY integration_states ALTER COLUMN id SET DEFAULT nextval('integration_states_id_seq'::regclass);
+ALTER TABLE ONLY public.integration_states ALTER COLUMN id SET DEFAULT nextval('public.integration_states_id_seq'::regclass);
 
 
 --
 -- Name: integrations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY integrations ALTER COLUMN id SET DEFAULT nextval('integrations_id_seq'::regclass);
+ALTER TABLE ONLY public.integrations ALTER COLUMN id SET DEFAULT nextval('public.integrations_id_seq'::regclass);
 
 
 --
 -- Name: message_bus id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY message_bus ALTER COLUMN id SET DEFAULT nextval('message_bus_id_seq'::regclass);
+ALTER TABLE ONLY public.message_bus ALTER COLUMN id SET DEFAULT nextval('public.message_bus_id_seq'::regclass);
 
 
 --
 -- Name: metrics id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY metrics ALTER COLUMN id SET DEFAULT nextval('metrics_id_seq'::regclass);
+ALTER TABLE ONLY public.metrics ALTER COLUMN id SET DEFAULT nextval('public.metrics_id_seq'::regclass);
 
 
 --
 -- Name: models id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY models ALTER COLUMN id SET DEFAULT nextval('models_id_seq'::regclass);
+ALTER TABLE ONLY public.models ALTER COLUMN id SET DEFAULT nextval('public.models_id_seq'::regclass);
 
 
 --
 -- Name: notifications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY notifications ALTER COLUMN id SET DEFAULT nextval('notifications_id_seq'::regclass);
+ALTER TABLE ONLY public.notifications ALTER COLUMN id SET DEFAULT nextval('public.notifications_id_seq'::regclass);
 
 
 --
 -- Name: proxies id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY proxies ALTER COLUMN id SET DEFAULT nextval('proxies_id_seq'::regclass);
+ALTER TABLE ONLY public.proxies ALTER COLUMN id SET DEFAULT nextval('public.proxies_id_seq'::regclass);
 
 
 --
 -- Name: que_jobs job_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY que_jobs ALTER COLUMN job_id SET DEFAULT nextval('que_jobs_job_id_seq'::regclass);
+ALTER TABLE ONLY public.que_jobs ALTER COLUMN job_id SET DEFAULT nextval('public.que_jobs_job_id_seq'::regclass);
 
 
 --
 -- Name: services id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY services ALTER COLUMN id SET DEFAULT nextval('services_id_seq'::regclass);
+ALTER TABLE ONLY public.services ALTER COLUMN id SET DEFAULT nextval('public.services_id_seq'::regclass);
 
 
 --
 -- Name: tenants id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tenants ALTER COLUMN id SET DEFAULT nextval('tenants_id_seq'::regclass);
+ALTER TABLE ONLY public.tenants ALTER COLUMN id SET DEFAULT nextval('public.tenants_id_seq'::regclass);
 
 
 --
 -- Name: update_states id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY update_states ALTER COLUMN id SET DEFAULT nextval('update_states_id_seq'::regclass);
+ALTER TABLE ONLY public.update_states ALTER COLUMN id SET DEFAULT nextval('public.update_states_id_seq'::regclass);
 
 
 --
 -- Name: usage_limits id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY usage_limits ALTER COLUMN id SET DEFAULT nextval('usage_limits_id_seq'::regclass);
+ALTER TABLE ONLY public.usage_limits ALTER COLUMN id SET DEFAULT nextval('public.usage_limits_id_seq'::regclass);
 
 
 --
 -- Name: applications applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY applications
+ALTER TABLE ONLY public.applications
     ADD CONSTRAINT applications_pkey PRIMARY KEY (id);
 
 
@@ -627,15 +666,23 @@ ALTER TABLE ONLY applications
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ar_internal_metadata
+ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: clients clients_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.clients
+    ADD CONSTRAINT clients_pkey PRIMARY KEY (id);
 
 
 --
 -- Name: entries entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY entries
+ALTER TABLE ONLY public.entries
     ADD CONSTRAINT entries_pkey PRIMARY KEY (id);
 
 
@@ -643,7 +690,7 @@ ALTER TABLE ONLY entries
 -- Name: integration_states integration_states_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY integration_states
+ALTER TABLE ONLY public.integration_states
     ADD CONSTRAINT integration_states_pkey PRIMARY KEY (id);
 
 
@@ -651,7 +698,7 @@ ALTER TABLE ONLY integration_states
 -- Name: integrations integrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY integrations
+ALTER TABLE ONLY public.integrations
     ADD CONSTRAINT integrations_pkey PRIMARY KEY (id);
 
 
@@ -659,7 +706,7 @@ ALTER TABLE ONLY integrations
 -- Name: message_bus message_bus_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY message_bus
+ALTER TABLE ONLY public.message_bus
     ADD CONSTRAINT message_bus_pkey PRIMARY KEY (id);
 
 
@@ -667,7 +714,7 @@ ALTER TABLE ONLY message_bus
 -- Name: metrics metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY metrics
+ALTER TABLE ONLY public.metrics
     ADD CONSTRAINT metrics_pkey PRIMARY KEY (id);
 
 
@@ -675,7 +722,7 @@ ALTER TABLE ONLY metrics
 -- Name: models models_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY models
+ALTER TABLE ONLY public.models
     ADD CONSTRAINT models_pkey PRIMARY KEY (id);
 
 
@@ -683,7 +730,7 @@ ALTER TABLE ONLY models
 -- Name: notifications notifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY notifications
+ALTER TABLE ONLY public.notifications
     ADD CONSTRAINT notifications_pkey PRIMARY KEY (id);
 
 
@@ -691,7 +738,7 @@ ALTER TABLE ONLY notifications
 -- Name: proxies proxies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY proxies
+ALTER TABLE ONLY public.proxies
     ADD CONSTRAINT proxies_pkey PRIMARY KEY (id);
 
 
@@ -699,7 +746,7 @@ ALTER TABLE ONLY proxies
 -- Name: que_jobs que_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY que_jobs
+ALTER TABLE ONLY public.que_jobs
     ADD CONSTRAINT que_jobs_pkey PRIMARY KEY (queue, priority, run_at, job_id);
 
 
@@ -707,7 +754,7 @@ ALTER TABLE ONLY que_jobs
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schema_migrations
+ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
@@ -715,7 +762,7 @@ ALTER TABLE ONLY schema_migrations
 -- Name: services services_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY services
+ALTER TABLE ONLY public.services
     ADD CONSTRAINT services_pkey PRIMARY KEY (id);
 
 
@@ -723,7 +770,7 @@ ALTER TABLE ONLY services
 -- Name: tenants tenants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tenants
+ALTER TABLE ONLY public.tenants
     ADD CONSTRAINT tenants_pkey PRIMARY KEY (id);
 
 
@@ -731,7 +778,7 @@ ALTER TABLE ONLY tenants
 -- Name: update_states update_states_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY update_states
+ALTER TABLE ONLY public.update_states
     ADD CONSTRAINT update_states_pkey PRIMARY KEY (id);
 
 
@@ -739,7 +786,7 @@ ALTER TABLE ONLY update_states
 -- Name: usage_limits usage_limits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY usage_limits
+ALTER TABLE ONLY public.usage_limits
     ADD CONSTRAINT usage_limits_pkey PRIMARY KEY (id);
 
 
@@ -747,342 +794,379 @@ ALTER TABLE ONLY usage_limits
 -- Name: index_applications_on_service_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_applications_on_service_id ON applications USING btree (service_id);
+CREATE INDEX index_applications_on_service_id ON public.applications USING btree (service_id);
 
 
 --
 -- Name: index_applications_on_tenant_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_applications_on_tenant_id ON applications USING btree (tenant_id);
+CREATE INDEX index_applications_on_tenant_id ON public.applications USING btree (tenant_id);
+
+
+--
+-- Name: index_clients_on_client_id_and_service_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_clients_on_client_id_and_service_id ON public.clients USING btree (client_id, service_id);
+
+
+--
+-- Name: index_clients_on_service_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_clients_on_service_id ON public.clients USING btree (service_id);
+
+
+--
+-- Name: index_clients_on_tenant_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_clients_on_tenant_id ON public.clients USING btree (tenant_id);
 
 
 --
 -- Name: index_entries_on_model_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_entries_on_model_id ON entries USING btree (model_id);
+CREATE INDEX index_entries_on_model_id ON public.entries USING btree (model_id);
 
 
 --
 -- Name: index_entries_on_tenant_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_entries_on_tenant_id ON entries USING btree (tenant_id);
+CREATE INDEX index_entries_on_tenant_id ON public.entries USING btree (tenant_id);
 
 
 --
 -- Name: index_integration_states_on_entry_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_integration_states_on_entry_id ON integration_states USING btree (entry_id);
+CREATE INDEX index_integration_states_on_entry_id ON public.integration_states USING btree (entry_id);
 
 
 --
 -- Name: index_integration_states_on_integration_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_integration_states_on_integration_id ON integration_states USING btree (integration_id);
+CREATE INDEX index_integration_states_on_integration_id ON public.integration_states USING btree (integration_id);
 
 
 --
 -- Name: index_integration_states_on_model_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_integration_states_on_model_id ON integration_states USING btree (model_id);
+CREATE INDEX index_integration_states_on_model_id ON public.integration_states USING btree (model_id);
 
 
 --
 -- Name: index_integration_states_on_model_id_and_integration_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_integration_states_on_model_id_and_integration_id ON integration_states USING btree (model_id, integration_id);
+CREATE UNIQUE INDEX index_integration_states_on_model_id_and_integration_id ON public.integration_states USING btree (model_id, integration_id);
 
 
 --
 -- Name: index_integrations_on_model_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_integrations_on_model_id ON integrations USING btree (model_id);
+CREATE INDEX index_integrations_on_model_id ON public.integrations USING btree (model_id);
 
 
 --
 -- Name: index_integrations_on_tenant_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_integrations_on_tenant_id ON integrations USING btree (tenant_id);
+CREATE INDEX index_integrations_on_tenant_id ON public.integrations USING btree (tenant_id);
 
 
 --
 -- Name: index_integrations_on_tenant_id_and_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_integrations_on_tenant_id_and_type ON integrations USING btree (tenant_id, type) WHERE (model_id IS NULL);
+CREATE UNIQUE INDEX index_integrations_on_tenant_id_and_type ON public.integrations USING btree (tenant_id, type) WHERE (model_id IS NULL);
 
 
 --
 -- Name: index_integrations_on_tenant_id_and_type_and_model_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_integrations_on_tenant_id_and_type_and_model_id ON integrations USING btree (tenant_id, type, model_id) WHERE (model_id IS NOT NULL);
+CREATE UNIQUE INDEX index_integrations_on_tenant_id_and_type_and_model_id ON public.integrations USING btree (tenant_id, type, model_id) WHERE (model_id IS NOT NULL);
 
 
 --
 -- Name: index_metrics_on_service_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_metrics_on_service_id ON metrics USING btree (service_id);
+CREATE INDEX index_metrics_on_service_id ON public.metrics USING btree (service_id);
 
 
 --
 -- Name: index_metrics_on_tenant_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_metrics_on_tenant_id ON metrics USING btree (tenant_id);
+CREATE INDEX index_metrics_on_tenant_id ON public.metrics USING btree (tenant_id);
 
 
 --
 -- Name: index_models_on_record_type_and_record_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_models_on_record_type_and_record_id ON models USING btree (record_type, record_id);
+CREATE UNIQUE INDEX index_models_on_record_type_and_record_id ON public.models USING btree (record_type, record_id);
 
 
 --
 -- Name: index_models_on_tenant_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_models_on_tenant_id ON models USING btree (tenant_id);
+CREATE INDEX index_models_on_tenant_id ON public.models USING btree (tenant_id);
 
 
 --
 -- Name: index_notifications_on_model_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_notifications_on_model_id ON notifications USING btree (model_id);
+CREATE INDEX index_notifications_on_model_id ON public.notifications USING btree (model_id);
 
 
 --
 -- Name: index_notifications_on_tenant_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_notifications_on_tenant_id ON notifications USING btree (tenant_id);
+CREATE INDEX index_notifications_on_tenant_id ON public.notifications USING btree (tenant_id);
 
 
 --
 -- Name: index_proxies_on_service_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_proxies_on_service_id ON proxies USING btree (service_id);
+CREATE INDEX index_proxies_on_service_id ON public.proxies USING btree (service_id);
 
 
 --
 -- Name: index_proxies_on_tenant_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_proxies_on_tenant_id ON proxies USING btree (tenant_id);
+CREATE INDEX index_proxies_on_tenant_id ON public.proxies USING btree (tenant_id);
 
 
 --
 -- Name: index_services_on_tenant_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_services_on_tenant_id ON services USING btree (tenant_id);
+CREATE INDEX index_services_on_tenant_id ON public.services USING btree (tenant_id);
 
 
 --
 -- Name: index_update_states_on_model_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_update_states_on_model_id ON update_states USING btree (model_id);
+CREATE UNIQUE INDEX index_update_states_on_model_id ON public.update_states USING btree (model_id);
 
 
 --
 -- Name: index_usage_limits_on_metric_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_usage_limits_on_metric_id ON usage_limits USING btree (metric_id);
+CREATE INDEX index_usage_limits_on_metric_id ON public.usage_limits USING btree (metric_id);
 
 
 --
 -- Name: index_usage_limits_on_tenant_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_usage_limits_on_tenant_id ON usage_limits USING btree (tenant_id);
+CREATE INDEX index_usage_limits_on_tenant_id ON public.usage_limits USING btree (tenant_id);
 
 
 --
 -- Name: table_added_at_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX table_added_at_index ON message_bus USING btree (added_at);
+CREATE INDEX table_added_at_index ON public.message_bus USING btree (added_at);
 
 
 --
 -- Name: table_channel_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX table_channel_id_index ON message_bus USING btree (channel, id);
+CREATE INDEX table_channel_id_index ON public.message_bus USING btree (channel, id);
 
 
 --
 -- Name: integration_states fk_rails_1133bc1397; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY integration_states
-    ADD CONSTRAINT fk_rails_1133bc1397 FOREIGN KEY (model_id) REFERENCES models(id);
+ALTER TABLE ONLY public.integration_states
+    ADD CONSTRAINT fk_rails_1133bc1397 FOREIGN KEY (model_id) REFERENCES public.models(id);
 
 
 --
 -- Name: proxies fk_rails_1b8514170a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY proxies
-    ADD CONSTRAINT fk_rails_1b8514170a FOREIGN KEY (service_id) REFERENCES services(id);
+ALTER TABLE ONLY public.proxies
+    ADD CONSTRAINT fk_rails_1b8514170a FOREIGN KEY (service_id) REFERENCES public.services(id);
 
 
 --
 -- Name: usage_limits fk_rails_29f5c8eedd; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY usage_limits
-    ADD CONSTRAINT fk_rails_29f5c8eedd FOREIGN KEY (metric_id) REFERENCES metrics(id);
+ALTER TABLE ONLY public.usage_limits
+    ADD CONSTRAINT fk_rails_29f5c8eedd FOREIGN KEY (metric_id) REFERENCES public.metrics(id);
 
 
 --
 -- Name: notifications fk_rails_3833a979e0; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY notifications
-    ADD CONSTRAINT fk_rails_3833a979e0 FOREIGN KEY (model_id) REFERENCES models(id);
+ALTER TABLE ONLY public.notifications
+    ADD CONSTRAINT fk_rails_3833a979e0 FOREIGN KEY (model_id) REFERENCES public.models(id);
 
 
 --
 -- Name: entries fk_rails_463bb0a9cc; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY entries
-    ADD CONSTRAINT fk_rails_463bb0a9cc FOREIGN KEY (model_id) REFERENCES models(id);
+ALTER TABLE ONLY public.entries
+    ADD CONSTRAINT fk_rails_463bb0a9cc FOREIGN KEY (model_id) REFERENCES public.models(id);
 
 
 --
 -- Name: models fk_rails_47bc1b5b2f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY models
-    ADD CONSTRAINT fk_rails_47bc1b5b2f FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+ALTER TABLE ONLY public.models
+    ADD CONSTRAINT fk_rails_47bc1b5b2f FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
+
+
+--
+-- Name: clients fk_rails_4904dbddb8; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.clients
+    ADD CONSTRAINT fk_rails_4904dbddb8 FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
 
 
 --
 -- Name: proxies fk_rails_574a99191a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY proxies
-    ADD CONSTRAINT fk_rails_574a99191a FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+ALTER TABLE ONLY public.proxies
+    ADD CONSTRAINT fk_rails_574a99191a FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
 
 
 --
 -- Name: integration_states fk_rails_5f9da38b71; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY integration_states
-    ADD CONSTRAINT fk_rails_5f9da38b71 FOREIGN KEY (entry_id) REFERENCES entries(id);
+ALTER TABLE ONLY public.integration_states
+    ADD CONSTRAINT fk_rails_5f9da38b71 FOREIGN KEY (entry_id) REFERENCES public.entries(id);
 
 
 --
 -- Name: update_states fk_rails_66e50c4ac9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY update_states
-    ADD CONSTRAINT fk_rails_66e50c4ac9 FOREIGN KEY (model_id) REFERENCES models(id);
+ALTER TABLE ONLY public.update_states
+    ADD CONSTRAINT fk_rails_66e50c4ac9 FOREIGN KEY (model_id) REFERENCES public.models(id);
 
 
 --
 -- Name: usage_limits fk_rails_7464a81431; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY usage_limits
-    ADD CONSTRAINT fk_rails_7464a81431 FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+ALTER TABLE ONLY public.usage_limits
+    ADD CONSTRAINT fk_rails_7464a81431 FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
 
 
 --
 -- Name: notifications fk_rails_7c99fe0556; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY notifications
-    ADD CONSTRAINT fk_rails_7c99fe0556 FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+ALTER TABLE ONLY public.notifications
+    ADD CONSTRAINT fk_rails_7c99fe0556 FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
+
+
+--
+-- Name: clients fk_rails_82a7d45fdb; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.clients
+    ADD CONSTRAINT fk_rails_82a7d45fdb FOREIGN KEY (service_id) REFERENCES public.services(id);
 
 
 --
 -- Name: integration_states fk_rails_9c9a857590; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY integration_states
-    ADD CONSTRAINT fk_rails_9c9a857590 FOREIGN KEY (integration_id) REFERENCES integrations(id);
+ALTER TABLE ONLY public.integration_states
+    ADD CONSTRAINT fk_rails_9c9a857590 FOREIGN KEY (integration_id) REFERENCES public.integrations(id);
 
 
 --
 -- Name: entries fk_rails_acc13c3cee; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY entries
-    ADD CONSTRAINT fk_rails_acc13c3cee FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+ALTER TABLE ONLY public.entries
+    ADD CONSTRAINT fk_rails_acc13c3cee FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
 
 
 --
 -- Name: applications fk_rails_c363b8b058; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY applications
-    ADD CONSTRAINT fk_rails_c363b8b058 FOREIGN KEY (service_id) REFERENCES services(id);
+ALTER TABLE ONLY public.applications
+    ADD CONSTRAINT fk_rails_c363b8b058 FOREIGN KEY (service_id) REFERENCES public.services(id);
 
 
 --
 -- Name: metrics fk_rails_c50b7368c1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY metrics
-    ADD CONSTRAINT fk_rails_c50b7368c1 FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+ALTER TABLE ONLY public.metrics
+    ADD CONSTRAINT fk_rails_c50b7368c1 FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
 
 
 --
 -- Name: metrics fk_rails_c7fa7e0e14; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY metrics
-    ADD CONSTRAINT fk_rails_c7fa7e0e14 FOREIGN KEY (service_id) REFERENCES services(id);
+ALTER TABLE ONLY public.metrics
+    ADD CONSTRAINT fk_rails_c7fa7e0e14 FOREIGN KEY (service_id) REFERENCES public.services(id);
 
 
 --
 -- Name: services fk_rails_c99dfff855; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY services
-    ADD CONSTRAINT fk_rails_c99dfff855 FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+ALTER TABLE ONLY public.services
+    ADD CONSTRAINT fk_rails_c99dfff855 FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
 
 
 --
 -- Name: applications fk_rails_cbcddd5826; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY applications
-    ADD CONSTRAINT fk_rails_cbcddd5826 FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+ALTER TABLE ONLY public.applications
+    ADD CONSTRAINT fk_rails_cbcddd5826 FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
 
 
 --
 -- Name: integrations fk_rails_cd54ced205; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY integrations
-    ADD CONSTRAINT fk_rails_cd54ced205 FOREIGN KEY (model_id) REFERENCES models(id);
+ALTER TABLE ONLY public.integrations
+    ADD CONSTRAINT fk_rails_cd54ced205 FOREIGN KEY (model_id) REFERENCES public.models(id);
 
 
 --
 -- Name: integrations fk_rails_d329ca1b17; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY integrations
-    ADD CONSTRAINT fk_rails_d329ca1b17 FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+ALTER TABLE ONLY public.integrations
+    ADD CONSTRAINT fk_rails_d329ca1b17 FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
 
 
 --
@@ -1104,6 +1188,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170605112051'),
 ('20170605112058'),
 ('20170612073714'),
-('20170620114832');
+('20170620114832'),
+('20181019101631');
 
 

--- a/test/fixtures/clients.yml
+++ b/test/fixtures/clients.yml
@@ -1,9 +1,11 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  tenant: one
   service: one
+  tenant: one
+  client_id: one
 
 two:
-  tenant: two
   service: two
+  tenant: two
+  client_id: two

--- a/test/fixtures/entries.yml
+++ b/test/fixtures/entries.yml
@@ -1,9 +1,16 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 application:
-  data: 
+  data:
+    client_id: one
   tenant: one
   model: application
+  created_at: <%= 1.week.ago %>
+
+client:
+  data:
+  tenant: two
+  model: client
   created_at: <%= 1.week.ago %>
 
 service:

--- a/test/fixtures/integrations.yml
+++ b/test/fixtures/integrations.yml
@@ -10,4 +10,4 @@ keycloak:
   model: service
   type: Integration::Keycloak
   configuration:
-    endpoint: 'http://example.com'
+    endpoint: 'http://id:pass@example.com'

--- a/test/fixtures/models.yml
+++ b/test/fixtures/models.yml
@@ -4,6 +4,10 @@ application:
   tenant: one
   record: one (Application)
 
+client:
+  tenant: two
+  record: two (Client)
+
 service:
   tenant: two
   record: two (Service)

--- a/test/jobs/process_entry_job_test.rb
+++ b/test/jobs/process_entry_job_test.rb
@@ -11,13 +11,22 @@ class ProcessEntryJobTest < ActiveJob::TestCase
     end
   end
 
-  test 'model integrations for' do
+  test 'model integrations for proxy' do
     job = ProcessEntryJob.new
     proxy = entries(:proxy)
 
     integrations = job.model_integrations_for(proxy)
 
     assert_equal 0, integrations.size
+  end
+
+  test 'model integrations for client' do
+    job = ProcessEntryJob.new
+    proxy = entries(:client)
+
+    integrations = job.model_integrations_for(proxy)
+
+    assert_equal 1, integrations.size
   end
 
   test 'creates keycloak integration for Proxy' do

--- a/test/services/integration/keycloak_service_test.rb
+++ b/test/services/integration/keycloak_service_test.rb
@@ -1,10 +1,42 @@
 require 'test_helper'
 
 class Integration::KeycloakServiceTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   def setup
   end
 
   def test_new
     assert Integration::KeycloakService.new(integrations(:keycloak))
+  end
+
+  test 'creating client' do
+    Client.delete_all
+
+    assert_difference Client.method(:count) do
+      subject.call(entries(:application))
+    end
+  end
+
+  test 'using existing client' do
+    assert_no_difference Client.method(:count) do
+      subject.call(entries(:application))
+    end
+  end
+
+  test 'schedules UpdateJob when creating Client' do
+    entry = entries(:application)
+    model = subject.call(entry)
+
+    assert_enqueued_with job: UpdateJob,
+                         args: [ model ] do
+      subject.call(entry)
+    end
+  end
+
+  protected
+
+  def subject
+    Integration::KeycloakService.new(integrations(:keycloak))
   end
 end


### PR DESCRIPTION
Fixes [THREESCALE-1346](https://issues.jboss.org/browse/THREESCALE-1346).

By introducing another model Client and using System API to find the last App with specific client_id we can synchronize changes even when Application is deleted and another one created with the same app_id. 