### PR TITLE
[config] fix strings in keycloak config

### DIFF
--- a/app/adapters/keycloak.rb
+++ b/app/adapters/keycloak.rb
@@ -96,7 +96,7 @@ class Keycloak
     end
 
     def self.attributes
-      Rails.application.config.x.keycloak.dig(:attributes) || Hash.new
+      Rails.application.config.x.keycloak.deep_symbolize_keys.dig(:attributes) || Hash.new
     end
   end
 

--- a/test/adapters/keycloak_test.rb
+++ b/test/adapters/keycloak_test.rb
@@ -68,7 +68,7 @@ class KeycloakTest < ActiveSupport::TestCase
         attributes: {
             serviceAccountsEnabled: true
         }
-    }
+    }.deep_stringify_keys
 
     Rails.application.config.x.stub(:keycloak, config) do
       client = Keycloak::Client.new(name: 'foo')


### PR DESCRIPTION
code expected symbols, but users usually write strings in YAML