### PR TITLE
OAuth allowed flows per application

### DIFF
--- a/app/adapters/keycloak.rb
+++ b/app/adapters/keycloak.rb
@@ -67,10 +67,10 @@ class Keycloak
     alias_attribute :client_id, :id
     alias_attribute :client_secret, :secret
 
-    delegate :to_json, to: :attributes
+    delegate :to_json, to: :to_h
     alias read to_json
 
-    def attributes
+    def to_h
       {
           name: name,
           description: description,

--- a/app/adapters/keycloak.rb
+++ b/app/adapters/keycloak.rb
@@ -132,6 +132,10 @@ class Keycloak
     end
   end
 
+  def access_token=(value)
+    @access_token.value = value
+  end
+
   protected
 
   JSON_TYPE = Mime[:json]

--- a/app/services/integration/keycloak_service.rb
+++ b/app/services/integration/keycloak_service.rb
@@ -91,9 +91,16 @@ class Integration::KeycloakService
     client
   end
 
+  OIDC_FLOWS = %i[
+    standard_flow_enabled implicit_flow_enabled service_accounts_enabled direct_access_grants_enabled
+  ].freeze
+  private_constant :OIDC_FLOWS
+
   def client_params(data)
     params = ActionController::Parameters.new(data)
-    params.permit(:client_id, :client_secret, :redirect_url, :state, :enabled, :name, :description)
+    params.permit(:client_id, :client_secret, :redirect_url,
+                  :state, :enabled, :name, :description,
+                  oidc_configuration: OIDC_FLOWS)
   end
 
   def remove(client)

--- a/test/adapters/keycloak_test.rb
+++ b/test/adapters/keycloak_test.rb
@@ -81,19 +81,19 @@ class KeycloakTest < ActiveSupport::TestCase
     Rails.application.config.x.stub(:keycloak, config) do
       client = Keycloak::Client.new(name: 'foo')
 
-      assert_includes client.attributes, :serviceAccountsEnabled
+      assert_includes client.to_h, :serviceAccountsEnabled
     end
   end
 
-  test 'client attributes' do
+  test 'client hash' do
     client = Keycloak::Client.new(name: 'name')
 
-    assert_includes client.attributes, :name
+    assert_includes client.to_h, :name
   end
 
   test 'client serialization' do
     client = Keycloak::Client.new(name: 'name')
 
-    assert_equal client.attributes.to_json, client.to_json
+    assert_equal client.to_h.to_json, client.to_json
   end
 end

--- a/test/adapters/keycloak_test.rb
+++ b/test/adapters/keycloak_test.rb
@@ -96,4 +96,16 @@ class KeycloakTest < ActiveSupport::TestCase
 
     assert_equal client.to_h.to_json, client.to_json
   end
+
+  test 'oauth flows' do
+    keycloak = { clientId: "client_id", implicitFlowEnabled: true, serviceAccountsEnabled: true }
+
+    assert_equal keycloak, Keycloak::Client.new({
+                                                    id: 'client_id',
+                                                    oidc_configuration: {
+                                                        implicit_flow_enabled: true,
+                                                        service_accounts_enabled: true,
+                                                    }
+                                                }).to_h.slice(*keycloak.keys)
+  end
 end

--- a/test/adapters/keycloak_test.rb
+++ b/test/adapters/keycloak_test.rb
@@ -12,6 +12,14 @@ class KeycloakTest < ActiveSupport::TestCase
     assert_kind_of URI, keycloak.endpoint
   end
 
+  test 'setting access token' do
+    subject = Keycloak.new('http://lvh.me:3000')
+
+    subject.access_token = 'sometoken'
+
+    assert_equal 'sometoken', subject.send(:access_token).token
+  end
+
   test 'endpoint normalization' do
     uri = URI('http://lvh.me:3000/auth/realm/name/')
 

--- a/test/fixtures/entries.yml
+++ b/test/fixtures/entries.yml
@@ -9,6 +9,18 @@ application:
 
 client:
   data:
+    name: "client name"
+    description: "client description"
+    state: "live"
+    enabled: true
+    redirect_url: "http://example.com"
+    client_id: "two_id"
+    client_secret: "two_secret"
+    oidc_configuration:
+      standard_flow_enabled: true
+      implicit_flow_enabled: true
+      service_accounts_enabled: true
+      direct_access_grants_enabled: true
   tenant: two
   model: client
   created_at: <%= 1.week.ago %>

--- a/test/services/integration/keycloak_service_test.rb
+++ b/test/services/integration/keycloak_service_test.rb
@@ -34,6 +34,27 @@ class Integration::KeycloakServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test 'client auth flows attributes' do
+    entry = entries(:client)
+
+    stub_request(:put, "http://example.com/clients-registrations/default/two_id").
+      with(
+        body: {
+            name: "client name", description: "client description",
+            clientId: "two_id", secret: "two_secret",
+            redirectUris: ["http://example.com"], attributes: {'3scale' => true},
+            enabled: true,
+            standardFlowEnabled: true, implicitFlowEnabled: true,
+            serviceAccountsEnabled: true, directAccessGrantsEnabled: true,
+        }.to_json,
+      ).to_return(status: 200)
+
+    subject.tap do |service|
+      service.adapter.access_token = 'foobar'
+      service.call(entry)
+    end
+  end
+
   protected
 
   def subject


### PR DESCRIPTION
Implement OAuth allowed flows for each Application based on information in https://issues.jboss.org/browse/THREESCALE-1948

Part of https://issues.jboss.org/browse/THREESCALE-774