### PR TITLE
[gemfile] fix missing public_suffix gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
             - zync-branch-{{ arch }}-master
 
       - run: bundle install --deployment --path vendor/bundle --jobs $(grep -c processor /proc/cpuinfo) --retry 3
+      - run: BUNDLE_WITHOUT=development:test bundle exec bin/rails runner --environment=production 'puts Rails.env'
 
       - save_cache:
           key: zync-bundle-{{ arch }}-{{ checksum "Gemfile.lock" }}

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'lograge'
 gem 'message_bus' # for publishing notifications about integration status
 
 gem 'validate_url'
+gem 'public_suffix', require: false # until https://github.com/perfectline/validates_url/issues/72 is fixed
 
 gem 'prometheus-client', require: %w[prometheus/client prometheus/middleware/exporter]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,6 +250,7 @@ DEPENDENCIES
   pry-rails
   pry-rescue
   pry-stack_explorer
+  public_suffix
   puma (~> 3.7)
   que
   rails (~> 5.2.2)
@@ -260,4 +261,4 @@ DEPENDENCIES
   webmock (~> 3.5)
 
 BUNDLED WITH
-   1.16.6
+   1.17.1


### PR DESCRIPTION
validate_url does not declare dependency on it, but uses it anyway (https://github.com/perfectline/validates_url/issues/72)

zync would fail to start when development and tests dependencies are not installed