### PR TITLE
[gemfile] no need to explicitly depend on public_suffix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem 'lograge'
 gem 'message_bus' # for publishing notifications about integration status
 
 gem 'validate_url'
-gem 'public_suffix', require: false # until https://github.com/perfectline/validates_url/issues/72 is fixed
 
 gem 'prometheus-client', require: %w[prometheus/client prometheus/middleware/exporter]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,6 @@ DEPENDENCIES
   pry-rails
   pry-rescue
   pry-stack_explorer
-  public_suffix
   puma (~> 3.7)
   que
   rails (~> 5.2.2)


### PR DESCRIPTION
validate_uri has been fixed in https://github.com/3scale/zync/pull/159