### PR TITLE
[Git ignore] .idea generated by RubyMine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+.idea
+
 # Ignore bundler config.
 /.bundle
 


### PR DESCRIPTION
Ignore the `.idea` folder just like we do for Porta:
https://github.com/3scale/porta/blob/4b1e6c55d4391cee5f7b1a0b47f6202d5aaf4710/.gitignore#L20

[This file is auto generated by RubyMine for its settings](https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-).