### PR TITLE
Keycloak timeouts

### DIFF
--- a/app/adapters/keycloak.rb
+++ b/app/adapters/keycloak.rb
@@ -6,8 +6,13 @@ require 'httpclient/include_client'
 # Keycloak adapter to create/update/delete Clients on using the Keycloak Client Registration API.
 class Keycloak
   extend ::HTTPClient::IncludeClient
-  include_http_client do |http|
-    http.debug_dev = $stderr if ENV.fetch('DEBUG', '0') == '1'
+  include_http_client do |client|
+    client.debug_dev = $stderr if ENV.fetch('DEBUG', '0') == '1'
+
+    Rails.application.config.x.keycloak.deep_symbolize_keys.fetch(:http_client, {})
+        .slice(:connect_timeout, :send_timeout, :receive_timeout).each do |key, value|
+      client.public_send("#{key}=", value)
+    end
   end
 
   attr_reader :endpoint

--- a/app/adapters/keycloak.rb
+++ b/app/adapters/keycloak.rb
@@ -239,9 +239,7 @@ class Keycloak
       @oauth_client = OAuth2::Client.new(client_id, client_secret,
                                    site: site,
                                          token_url: 'protocol/openid-connect/token') do |builder|
-        builder.adapter :httpclient do |client|
-          client.debug_dev = http_client.debug_dev
-        end
+        builder.adapter(:httpclient).last.instance_variable_set(:@client, http_client)
       end
       @value = Concurrent::IVar.new
       freeze

--- a/config/keycloak.yml
+++ b/config/keycloak.yml
@@ -6,8 +6,15 @@ example:
     serviceAccountsEnabled: true
     directAccessGrantsEnabled: true
 
+default: &default
+  http_client:
+    connect_timeout: 3
+    send_timeout: 3
+    receive_timeout: 3
+
 development:
 
 production:
+  <<: *default
 
 test:


### PR DESCRIPTION
Ability to configure timeouts of the http client used to call Keycloak.
Set default timeout in production to 3 seconds.