### PR TITLE
[db] disable statement timeout in que db migration

### DIFF
--- a/db/migrate/20190410112007_upgrade_que.rb
+++ b/db/migrate/20190410112007_upgrade_que.rb
@@ -1,11 +1,17 @@
 class UpgradeQue < ActiveRecord::Migration[5.2]
   def self.up
-    # The current version as of this migration's creation.
-    Que.migrate! version: 4
+    Que.transaction do
+      Que.execute 'SET LOCAL statement_timeout TO DEFAULT;'
+      # The current version as of this migration's creation.
+      Que.migrate! version: 4
+    end
   end
 
   def self.down
-    # Migrate back to version 3
-    Que.migrate! version: 3
+    Que.transaction do
+      Que.execute 'SET LOCAL statement_timeout TO DEFAULT;'
+      # Migrate back to version 3
+      Que.migrate! version: 3
+    end
   end
 end


### PR DESCRIPTION
Migration can't really finish in 5 seconds.