### PR TITLE
Add que container to imagechange trigger

### DIFF
--- a/openshift/04-deploymentconfig-template.yml
+++ b/openshift/04-deploymentconfig-template.yml
@@ -160,6 +160,7 @@ objects:
         automatic: true
         containerNames:
         - zync
+        - que
         from:
           kind: ImageStreamTag
           name: zync:latest


### PR DESCRIPTION
Imagechange trigger was missing new `que` container.

It has been added, so now `que` container points to ImageStream `zync:latest`, and ImageChange trigger pointing to `zync-latest` now manages both `zync` and `que` containers.