### PR TITLE
Do not use begin/rescue in tests

### DIFF
--- a/test/adapters/generic_adapter_test.rb
+++ b/test/adapters/generic_adapter_test.rb
@@ -35,16 +35,17 @@ class GenericAdapterTest < ActiveSupport::TestCase
         to_return(status: 200, headers: { 'Content-Type' => 'application/json' },
                   body: { token_endpoint: 'protocol/openid-connect/token' }.to_json)
 
-    stub_request(:post, 'http://lvh.me:3000/auth/realm/name/protocol/openid-connect/token').to_timeout
+    get_token = stub_request(:post, 'http://lvh.me:3000/auth/realm/name/protocol/openid-connect/token').to_timeout
 
     adapter = GenericAdapter.new('http://id:secret@lvh.me:3000/auth/realm/name')
 
-    begin
+    error = assert_raises GenericAdapter::OIDC::AuthenticationError do
       adapter.test
-    rescue GenericAdapter::OIDC::AuthenticationError => error
-      assert_kind_of Faraday::TimeoutError, error.cause
-      assert error.bugsnag_meta_data.presence
     end
+
+    assert_kind_of Faraday::TimeoutError, error.cause
+    assert error.bugsnag_meta_data.presence
+    assert_requested get_token
   end
 
   test 'create client' do

--- a/test/adapters/generic_adapter_test.rb
+++ b/test/adapters/generic_adapter_test.rb
@@ -39,10 +39,22 @@ class GenericAdapterTest < ActiveSupport::TestCase
 
     adapter = GenericAdapter.new('http://id:secret@lvh.me:3000/auth/realm/name')
 
-    error = assert_raises GenericAdapter::OIDC::AuthenticationError do
+    log = Object.new
+    class << log
+      def error_object
+        @error
+      end
+
+      def error(object)
+        @error = object
+      end
+    end
+
+    Rails.logger.stub :error, log.method(:error) do
       adapter.test
     end
 
+    error = log.error_object
     assert_kind_of Faraday::TimeoutError, error.cause
     assert error.bugsnag_meta_data.presence
     assert_requested get_token

--- a/test/adapters/keycloak_adapter_test.rb
+++ b/test/adapters/keycloak_adapter_test.rb
@@ -35,16 +35,16 @@ class KeycloakAdapterTest < ActiveSupport::TestCase
         to_return(status: 200, headers: { 'Content-Type' => 'application/json' },
                   body: { token_endpoint: 'protocol/openid-connect/token' }.to_json)
 
-    stub_request(:post, 'http://lvh.me:3000/auth/realm/name/protocol/openid-connect/token').to_timeout
+    get_token = stub_request(:post, 'http://lvh.me:3000/auth/realm/name/protocol/openid-connect/token').to_timeout
 
     keycloak = KeycloakAdapter.new('http://id:secret@lvh.me:3000/auth/realm/name')
 
-    begin
+    error = assert_raises KeycloakAdapter::OIDC::AuthenticationError do
       keycloak.test
-    rescue KeycloakAdapter::OIDC::AuthenticationError => error
-      assert_kind_of Faraday::TimeoutError, error.cause
-      assert error.bugsnag_meta_data.presence
     end
+    assert_kind_of Faraday::TimeoutError, error.cause
+    assert error.bugsnag_meta_data.presence
+    assert_requested get_token
   end
 
   test 'test' do


### PR DESCRIPTION
Stub Rails.logger.error

When fetching headers, we rescue any authentication error and set the
headers as application/json 
https://github.com/3scale/zync/blob/464cd87fda2275468ad4a94d9fbb54cfe98df10e/app/adapters/generic_adapter.rb#L136

The test rescues an error that is never raised