### PR TITLE
[que] de-duplicate update and process integration jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'bootsnap'
 
 gem 'que', '>= 1.0.0.beta3'
 gem 'que-web'
+gem 'baby_squeel'
 
 gem 'bugsnag'
 # bugsnag-capistrano 2.x does not have a rake task to report deploys

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,9 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     ansi (1.5.0)
     arel (9.0.0)
+    baby_squeel (1.2.0)
+      activerecord (>= 4.2.0)
+      polyamorous (~> 1.3)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     bootsnap (1.4.4)
@@ -149,6 +152,8 @@ GEM
       rack (>= 1.2, < 3)
     parslet (1.8.2)
     pg (1.1.4)
+    polyamorous (1.3.3)
+      activerecord (>= 3.0)
     prometheus-client (0.9.0)
       quantile (~> 0.2.1)
     pry (0.12.2)
@@ -278,6 +283,7 @@ PLATFORMS
 
 DEPENDENCIES
   3scale-api (~> 0.1.9)
+  baby_squeel
   bootsnap
   bugsnag
   bugsnag-capistrano (< 2)

--- a/app/jobs/process_integration_entry_job.rb
+++ b/app/jobs/process_integration_entry_job.rb
@@ -5,6 +5,8 @@
 class ProcessIntegrationEntryJob < ApplicationJob
   queue_as :default
 
+  self.deduplicate = true
+
   delegate :instrument, to: 'ActiveSupport::Notifications'
 
   def perform(integration, model, service: DiscoverIntegrationService.call(integration))

--- a/app/jobs/update_job.rb
+++ b/app/jobs/update_job.rb
@@ -2,7 +2,6 @@
 # Uses FetchService to get Entity and persist it in database.
 # Maintains UpdateState and can be only one running at a time by using a lock on model.
 
-require 'que/active_record/model'
 
 class UpdateJob < ApplicationJob
   include JobWithTimestamp
@@ -11,20 +10,14 @@ class UpdateJob < ApplicationJob
   retry_on Errno::ECONNREFUSED, wait: :exponentially_longer, attempts: 10
   retry_on Model::LockTimeoutError, wait: :exponentially_longer, attempts: 10
 
+  self.deduplicate = true
+
   def initialize(*)
     super
     @fetch = FetchService
   end
 
   attr_reader :fetch
-
-  def relation
-    record = self.class.model
-    arguments = serialize.slice('arguments')
-    record.where.has {
-      args.op('@>', quoted([arguments].to_json))
-    }
-  end
 
   def perform(model)
     UpdateState.acquire_lock(model) do |state|
@@ -35,18 +28,6 @@ class UpdateJob < ApplicationJob
       entry = fetch.call(model)
 
       state.update_attributes(success: entry.save, finished_at: timestamp)
-    end
-  end
-
-  def self.model
-    Que::ActiveRecord::Model.by_job_class(to_s)
-  end
-
-  def self.perform_later(*args)
-    model.transaction do
-      job = job_or_instantiate(*args)
-      job.relation.delete_all
-      job.enqueue
     end
   end
 end

--- a/test/jobs/update_job_test.rb
+++ b/test/jobs/update_job_test.rb
@@ -39,7 +39,7 @@ class UpdateJobTest < ActiveJob::TestCase
     adapter.enqueue(job)
 
     assert_difference job.relation.method(:count), -1 do
-      UpdateJob.perform_later(job) # this is not using the same adapter, so it actually just removes previous one
+      ApplicationJob.perform_later(job) # this is not using the same adapter, so it actually just removes previous one
     end
   end
 

--- a/test/jobs/update_job_test.rb
+++ b/test/jobs/update_job_test.rb
@@ -13,6 +13,36 @@ class UpdateJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'relation' do
+    application = UpdateJob.new(models(:application))
+    client = UpdateJob.new(models(:client))
+
+    refute_equal application.relation.to_sql, client.relation.to_sql
+
+    adapter = ActiveJob::QueueAdapters::QueAdapter.new
+
+    assert_difference application.relation.method(:count), 2 do
+      adapter.enqueue(application)
+      adapter.enqueue(application)
+
+      assert_difference client.relation.method(:count), 2 do
+        adapter.enqueue(client)
+        adapter.enqueue(client)
+      end
+    end
+  end
+
+  test 'perform later' do
+    adapter = ActiveJob::QueueAdapters::QueAdapter.new
+    job = UpdateJob.new(models(:application))
+
+    adapter.enqueue(job)
+
+    assert_difference job.relation.method(:count), -1 do
+      UpdateJob.perform_later(job) # this is not using the same adapter, so it actually just removes previous one
+    end
+  end
+
   test 'creates entry' do
     model = Model.create!(tenant: tenants(:two), record: applications(:two))
 


### PR DESCRIPTION
there is no need for previous jobs with the same parameters
they always take the last data from the database, so there is no reason to have more of them in flight