### PR TITLE
fix uri parse error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 group :test do
   gem 'minitest-reporters'
+  gem 'minitest-stub-const'
   gem 'webmock'
   gem 'codecov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    minitest-stub-const (0.5)
     modware (0.1.3)
       key_struct (~> 0.4)
     msgpack (1.2.10)
@@ -344,6 +345,7 @@ DEPENDENCIES
   lograge
   message_bus
   minitest-reporters
+  minitest-stub-const
   oauth2
   pg (>= 0.20)
   prometheus-client

--- a/app/adapters/abstract_adapter.rb
+++ b/app/adapters/abstract_adapter.rb
@@ -67,7 +67,7 @@ class AbstractAdapter
     HTTPClient.new do
       self.debug_dev = $stderr if ENV.fetch('DEBUG', '0') == '1'
 
-      self.set_auth endpoint, *endpoint.auth
+      self.set_auth endpoint.uri.dup, *endpoint.auth
 
       Rails.application.config.x.http_client.deep_symbolize_keys
           .slice(:connect_timeout, :send_timeout, :receive_timeout).each do |key, value|

--- a/test/adapters/abstract_adapter_test.rb
+++ b/test/adapters/abstract_adapter_test.rb
@@ -23,4 +23,10 @@ class AbstractAdapterTest < ActiveSupport::TestCase
     assert_equal uri,
                  subject.new('http://id:secret@lvh.me:3000/auth/realm/name/').endpoint
   end
+
+  test 'http_client' do
+    HTTPClient::Util.stub_const(:AddressableEnabled, false) do
+      assert_kind_of subject, subject.new('http://id:secret@example.com')
+    end
+  end
 end


### PR DESCRIPTION
Very interesting error. Our test suite depends on webmock, which depends on addressable. httpclient uses addressable if available. That means URLs are parsed differently in test environment and production one.