### PR TITLE
[k8s] ignore owner references that zync has no permission to

### DIFF
--- a/app/services/integration/kubernetes_service.rb
+++ b/app/services/integration/kubernetes_service.rb
@@ -61,6 +61,9 @@ class Integration::KubernetesService < Integration::ServiceBase
     end
 
     resource
+  rescue K8s::Error::Forbidden
+    # likely some resource like the operator
+    resource
   end
 
   def get_owner


### PR DESCRIPTION
When deployed by the operator, 3scale objects have the following owner reference:

```yaml
ownerReferences:
    - apiVersion: apps.3scale.net/v1alpha1
      kind: APIManager
      name: example-apimanager-s3
      uid: 3fcf9ead-a2f3-11e9-b57e-0a543109227c
      controller: true
      blockOwnerDeletion: true
```

And zync won't have permissions to read that object. So just stop the recursion and use the latest valid object as a root owner reference.

/cc @miguelsorianod 