### PR TITLE
Bump license_finder from 5.9.2 to 5.10.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ group :development, :test do
   gem 'pry-rescue'
   gem 'pry-stack_explorer'
 
-  gem 'license_finder', '~> 5.9'
+  gem 'license_finder', '~> 5.10'
   gem 'license_finder_xml_reporter', git: 'https://github.com/3scale/license_finder_xml_reporter.git', tag: '1.0.0'
 
   # gem 'httplog'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       yajl-ruby (~> 1.4.0)
       yaml-safe_load_stream (~> 0.1)
     key_struct (0.4.2)
-    license_finder (5.9.2)
+    license_finder (5.10.2)
       bundler
       rubyzip
       thor
@@ -263,7 +263,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     ruby-progressbar (1.10.0)
-    rubyzip (1.2.3)
+    rubyzip (2.0.0)
     safe_yaml (1.0.5)
     schema_monkey (2.1.5)
       activerecord (>= 4.2)
@@ -341,7 +341,7 @@ DEPENDENCIES
   codecov
   httpclient!
   k8s-client (>= 0.10)
-  license_finder (~> 5.9)
+  license_finder (~> 5.10)
   license_finder_xml_reporter!
   lograge
   message_bus
@@ -368,4 +368,4 @@ DEPENDENCIES
   yabeda-rails
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
Bumps version of license_finder gem to v5.10.2, also upgrading rubyzip to v2.0.0.

Current version of rubyzip bundled with license_finder (v5.9.2) requires a version of rubyzip (v1.2.3) recently marked in [CVE-2019-16892](https://nvd.nist.gov/vuln/detail/CVE-2019-16892) 

Closes [THREESCALE-3732](https://issues.jboss.org/browse/THREESCALE-3732).