### PR TITLE
Bump rubyzip version from 1.2.3 to 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,8 @@ group :development, :test do
 
   gem 'license_finder', '~> 5.9'
   gem 'license_finder_xml_reporter', git: 'https://github.com/3scale/license_finder_xml_reporter.git', tag: '1.0.0'
+  # rubyzip is a transitive depencency from license_finder with vulnerability on < 1.3.0
+  gem 'rubyzip', '>= 1.3.0'
 
   # gem 'httplog'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,7 +263,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     ruby-progressbar (1.10.0)
-    rubyzip (1.2.3)
+    rubyzip (2.0.0)
     safe_yaml (1.0.5)
     schema_monkey (2.1.5)
       activerecord (>= 4.2)
@@ -359,6 +359,7 @@ DEPENDENCIES
   que-web
   rails (~> 5.2.3)
   responders (~> 3.0.0)
+  rubyzip (>= 1.3.0)
   schema_plus_enums
   tzinfo-data
   validate_url
@@ -368,4 +369,4 @@ DEPENDENCIES
   yabeda-rails
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
Current version of rubyzip (1.2.3) bundled with license_finder v5.9.2 has been recently marked in [CVE-2019-16892](https://nvd.nist.gov/vuln/detail/CVE-2019-16892).

This PR bumps version of rubyzip preserving version of license_finder which we are not ready to upgrade yet. This is the same approach adopted by https://github.com/3scale/3scale_toolbox/pull/217.

Closes [THREESCALE-3732](https://issues.jboss.org/browse/THREESCALE-3732).