### PR TITLE
Route termination options follow public url scheme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,9 @@ jobs:
       - image: circleci/buildpack-deps:latest
         environment:
           POSGRES_CONTAINER_NAME: db
-          DATABASE_URL: postgresql://postgres:@db:5432/zync
+          DATABASE_URL: postgresql://postgres:postgres@db:5432/zync
           POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
           POSTGRES_DB: zync
           RAILS_ENV: production
     steps:
@@ -16,7 +17,7 @@ jobs:
       - setup_remote_docker
       - run: docker build --tag zync:build --file ./Dockerfile .
       - run: docker network create net0
-      - run: docker run --net net0 --name ${POSGRES_CONTAINER_NAME} -d -p 5432:5432 -e POSTGRES_USER=${POSTGRES_USER} -e POSTGRES_DB=${POSTGRES_DB} postgres:10-alpine
+      - run: docker run --net net0 --name ${POSGRES_CONTAINER_NAME} -d -p 5432:5432 -e POSTGRES_USER=${POSTGRES_USER} -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -e POSTGRES_DB=${POSTGRES_DB} postgres:10-alpine
       - run:
           command: |
             docker run --net net0 -e RAILS_ENV=${RAILS_ENV} -e DATABASE_URL=${DATABASE_URL} \

--- a/app/services/integration/kubernetes_service.rb
+++ b/app/services/integration/kubernetes_service.rb
@@ -135,18 +135,19 @@ class Integration::KubernetesService < Integration::ServiceBase
   class RouteSpec < K8s::Resource
     def initialize(url, service, port)
       uri = URI(url)
+      tls_options = {
+        insecureEdgeTerminationPolicy: 'Redirect',
+        termination: 'edge'
+      } if uri.class == URI::HTTPS
+
       super({
         host: uri.host || uri.path,
         port: { targetPort: port },
-        tls: {
-          insecureEdgeTerminationPolicy: 'Redirect',
-          termination: 'edge'
-        },
         to: {
           kind: 'Service',
           name: service
         }
-      })
+      }.merge(tls: tls_options))
     end
   end
 

--- a/test/lib/prometheus/que_stats_test.rb
+++ b/test/lib/prometheus/que_stats_test.rb
@@ -21,10 +21,12 @@ class Prometheus::QueStatsTest < ActiveSupport::TestCase
     assert Prometheus::QueStats.job_stats('1 > 0')
   end
 
-  uses_transaction :test_readonly_transaction
-  def test_readonly_transaction
-    Prometheus::QueStats.stub(:read_only_transaction, true) do
-      Prometheus::QueStats.worker_stats
+  class WithTransaction < ActiveSupport::TestCase
+    uses_transaction :test_readonly_transaction
+    def test_readonly_transaction
+      Prometheus::QueStats.stub(:read_only_transaction, true) do
+        Prometheus::QueStats.worker_stats
+      end
     end
   end
 

--- a/test/services/kubernetes_service_test.rb
+++ b/test/services/kubernetes_service_test.rb
@@ -65,4 +65,33 @@ class Integration::KubernetesServiceTest < ActiveSupport::TestCase
 
     service.call(proxy)
   end
+
+  class RouteSpec < ActiveSupport::TestCase
+    test 'secure routes' do
+      url = 'https://my-api.example.com'
+      service_name = 'My API'
+      port = 7443
+      spec = Integration::KubernetesService::RouteSpec.new(url, service_name, port)
+      json = {
+        host: "my-api.example.com",
+        port: {targetPort: 7443},
+        to: {kind: "Service", name: "My API"},
+        tls: {insecureEdgeTerminationPolicy: "Redirect", termination: "edge"}
+      }
+      assert_equal json, spec.to_hash
+
+
+      url = 'http://my-api.example.com'
+      service_name = 'My API'
+      port = 7780
+      spec = Integration::KubernetesService::RouteSpec.new(url, service_name, port)
+      json = {
+        host: "my-api.example.com",
+        port: {targetPort: 7780},
+        to: {kind: "Service", name: "My API"},
+        tls: nil
+      }
+      assert_equal json, spec.to_hash
+    end
+  end
 end


### PR DESCRIPTION
If public route was created with `http:` scheme, do not enforce secure route edge redirect

Fixes THREESCALE-3545

#### TODO

- [x] Add tests for RouteSpec
- [x] Test in live OpenShift


#### Issues/Questions

The following does not prevent the merge of this PR but we should take into account that when the environment variable `KUBERNETES_ROUTE_TLS` is set to `1`, `t` or `true` then it will prevent creating 
non secure routes, which might be an issue as **Porta** has something different from **OpenShift**

This prevents removing the `:tls` option https://github.com/3scale/zync/blob/726962b98feb15f1859b0c1ad8ae72b7b6e71028/app/services/integration/kubernetes_service.rb#L6-L7

It is used in https://github.com/3scale/zync/blob/726962b98feb15f1859b0c1ad8ae72b7b6e71028/app/services/integration/kubernetes_service.rb#L263-L271

But the integration service builds all routes for both staging and production endpoint, so disabling the `maintain_tls_spec` for the integration service is not possible because for example, staging route can be HTTP and production route can be HTTPS

https://github.com/3scale/zync/blob/726962b98feb15f1859b0c1ad8ae72b7b6e71028/app/services/integration/kubernetes_service.rb#L153-L158

### Openshift testing

Using this Build config

```yaml
apiVersion: v1
kind: Template
metadata:
  name: "zync-build"
message: "3scale AMP zync builder"
objects:

- kind: "BuildConfig"
  apiVersion: "v1"
  metadata:
    name: "zync-build"
  spec:
    source:
      git:
        uri: "https://github.com/3scale/zync"
        ref: "THREESCALE-3545"
    output:
      to:
        kind: "ImageStreamTag"
        name: "amp-zync:latest"

    strategy:
      type: Docker
      dockerStrategy:
```

### Screenshots

![image](https://user-images.githubusercontent.com/64276/67685931-f57ce080-f9a6-11e9-8edd-c9bd19e35683.png)

![image](https://user-images.githubusercontent.com/64276/67685872-e1d17a00-f9a6-11e9-9ee0-3ad93ab3c8ea.png)


### Caveats

Due to OpenShift router limitation,[ the HTTP and HTTPS ports are automatically set by OpenShift](https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html)
If you use different ports than `ROUTER_SERVICE_HTTP_PORT` and `ROUTER_SERVICE_HTTPS_PORT`, they are not taken into account

