### PR TITLE
Allow disabling integrations

### DIFF
--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -17,6 +17,6 @@ class Integration < ApplicationRecord
   end
 
   def enabled?
-    true
+    Rails.application.config.integrations.fetch(self.class.name.demodulize.downcase, true)
   end
 end

--- a/app/models/integration/kubernetes.rb
+++ b/app/models/integration/kubernetes.rb
@@ -7,7 +7,7 @@ class Integration::Kubernetes < Integration
   validates :server, url: { allow_nil: true, no_local: true }
 
   def enabled?
-    K8s::Client === K8s::Client.autoconfig
+    super && K8s::Client === K8s::Client.autoconfig
   rescue K8s::Error::Configuration
     false
   rescue => error

--- a/app/models/integration/rest.rb
+++ b/app/models/integration/rest.rb
@@ -7,6 +7,6 @@ class Integration::REST < Integration
   validates :endpoint, url: { allow_nil: true, no_local: true }
 
   def enabled?
-    endpoint.present?
+    super && endpoint.present?
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,8 @@ module Zync
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 
+    config.integrations = config_for(:integrations)
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/integrations.yml
+++ b/config/integrations.yml
@@ -1,0 +1,11 @@
+shared: &shared
+  kubernetes: <%= ENV.fetch('DISABLE_K8S_ROUTES_CREATION', '0') == '0' %>
+
+production:
+  <<: *shared
+
+development:
+  <<: *shared
+
+test:
+  <<: *shared

--- a/test/models/integration_test.rb
+++ b/test/models/integration_test.rb
@@ -13,4 +13,56 @@ class IntegrationTest < ActiveSupport::TestCase
     assert_equal [ keycloak ], Integration.tenant_or_model(nil, model)
     assert_equal [ one ], Integration.tenant_or_model(tenant, nil)
   end
+
+  test 'enabled is by integration' do
+    with_integration keycloak: false, rest: true, kubernetes: true do
+      assert Integration.new.enabled?
+      refute Integration::Keycloak.new.enabled?
+    end
+  end
+
+  test 'rest enabled?' do
+      integration = Integration::REST.new
+      integration.endpoint = 'https://rest.example.com/endpoint'
+      assert integration.enabled?
+
+      integration.endpoint = nil
+      refute integration.enabled?
+
+      with_integration rest: false do
+      integration = Integration::REST.new
+      integration.endpoint = 'https://rest.example.com/endpoint'
+      refute integration.enabled?
+
+      integration.endpoint = nil
+      refute integration.enabled?
+    end
+  end
+
+  test 'kubernetes enabled?' do
+    client = K8s::Client.new(nil)
+    integration = Integration::Kubernetes.new
+
+    K8s::Client.stub(:autoconfig, client) do
+      assert integration.enabled?
+
+      with_integration kubernetes: false do
+        refute integration.enabled?
+      end
+    end
+
+    K8s::Client.stub(:autoconfig, nil) do
+      refute integration.enabled?
+    end
+
+    with_integration kubernetes: false do
+      refute integration.enabled?
+    end
+  end
+
+  protected
+
+  def with_integration(opts = {}, &block)
+    Rails.application.config.stub(:integrations, opts.with_indifferent_access, &block)
+  end
 end

--- a/test/models/integration_test.rb
+++ b/test/models/integration_test.rb
@@ -22,7 +22,7 @@ class IntegrationTest < ActiveSupport::TestCase
   end
 
   test 'rest enabled?' do
-      integration = Integration::REST.new
+    integration = Integration::REST.new
       integration.endpoint = 'https://rest.example.com/endpoint'
       assert integration.enabled?
 


### PR DESCRIPTION
Disable routes creations for Kubernetes Integration by setting:
DISABLE_K8S_ROUTES_CREATION=1