### PR TITLE
[random-failure] Do not forget super in after_teardown

### DIFF
--- a/test/services/kubernetes_service_test.rb
+++ b/test/services/kubernetes_service_test.rb
@@ -13,6 +13,7 @@ class Integration::KubernetesServiceTest < ActiveSupport::TestCase
 
   def after_teardown
     ENV.replace(@_env)
+    super
   end
 
   test 'create ingress ' do


### PR DESCRIPTION
Otherwise ROLLBACK will not be invoked
Thus transactional tests will still run inside the same global transaction


**How to reproduce:**

```shell
git checkout d8a36dfacd8ad8b2ddd56d75ec339533b953ce66
rails test  --seed 54917
```

**Fixing:**
https://app.circleci.com/pipelines/github/3scale/zync/807/workflows/a0a60d3a-1425-44bc-9335-ab3666c3194a/jobs/1426


```
  1) Error:
Prometheus::QueStatsTest::WithTransaction#test_readonly_transaction:
ActiveRecord::StatementInvalid: PG::ActiveSqlTransaction: ERROR:  SET TRANSACTION ISOLATION LEVEL must be called before any query
: SET TRANSACTION ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:75:in `exec'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:75:in `block (2 levels) in execute'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:74:in `block in execute'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:581:in `block (2 levels) in log'
    /usr/local/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:580:in `block in log'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `log'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:73:in `execute'
    /home/circleci/zync/lib/prometheus/que_stats.rb:41:in `block in execute'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:267:in `block in transaction'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/transaction.rb:239:in `block in within_new_transaction'
    /usr/local/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/transaction.rb:236:in `within_new_transaction'
    /home/circleci/zync/vendor/bundle/ruby/2.4.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:267:in `transaction'
    /home/circleci/zync/lib/prometheus/que_stats.rb:39:in `execute'
    /home/circleci/zync/lib/prometheus/que_stats.rb:15:in `worker_stats'
    /home/circleci/zync/test/lib/prometheus/que_stats_test.rb:28:in `block in test_readonly_transaction'

```