### PR TITLE
Upgrade PostgreSQL client to 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,33 @@
 FROM registry.access.redhat.com/ubi7/ruby-25
 
 USER root
-RUN rpm -Uvh http://yum.postgresql.org/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm \
+
   && yum update -y \
   && yum remove -y postgresql \
   && yum install -y postgresql96 postgresql96-devel postgresql96-libs \
   && yum clean all \
   && rm -rf /var/cache/yum
 
-RUN source ${APP_ROOT}/etc/scl_enable \
- && gem install bundler --version=2.0.1 --no-document
+USER default
+WORKDIR ${APP_ROOT}
 
-COPY Gemfile* ./
+RUN source ${APP_ROOT}/etc/scl_enable \
+  && gem install bundler --version=2.0.1 --no-document
+
+COPY --chown=default:root Gemfile* ./
 RUN source ${APP_ROOT}/etc/scl_enable \
   && bundle config build.pg --with-pg-config=/usr/pgsql-9.6/bin/pg_config \
   && bundle install --deployment --path vendor/bundle --jobs $(grep -c processor /proc/cpuinfo) --retry 3
-COPY . .
+
+COPY --chown=default:root . .
+
 ENV RAILS_LOG_TO_STDOUT=1
-USER root
-RUN mkdir -p tmp log; chmod -vfR g+w tmp log
-USER default
 RUN source ${APP_ROOT}/etc/scl_enable \
-&& bundle exec bin/rails server -e production -d; \
-rm -rf tmp/pids
-USER root
-RUN chmod -fR g+w tmp/cache
-USER default
+  && bundle exec bin/rails server -e production -d; \
+  rm -rf tmp/pids
+
+RUN mkdir -p -m 0775 tmp/cache log \
+  && chown -fR default tmp log db \
+  && chmod -fR g+w tmp log db
 
 CMD [".s2i/bin/run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM registry.access.redhat.com/ubi7/ruby-25
 
 USER root
-
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm\
   && yum update -y \
   && yum remove -y postgresql \
-  && yum install -y postgresql96 postgresql96-devel postgresql96-libs \
+  && yum install -y postgresql1pg 0 postgresql10-devel postgresql10-libs \
   && yum clean all \
   && rm -rf /var/cache/yum
 
@@ -16,7 +16,7 @@ RUN source ${APP_ROOT}/etc/scl_enable \
 
 COPY --chown=default:root Gemfile* ./
 RUN source ${APP_ROOT}/etc/scl_enable \
-  && bundle config build.pg --with-pg-config=/usr/pgsql-9.6/bin/pg_config \
+  && bundle config build.pg --with-pg-config=/usr/pgsql-10/bin/pg_config \
   && bundle install --deployment --path vendor/bundle --jobs $(grep -c processor /proc/cpuinfo) --retry 3
 
 COPY --chown=default:root . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
 FROM registry.access.redhat.com/ubi7/ruby-25
+
+USER root
+RUN rpm -Uvh http://yum.postgresql.org/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm \
+  && yum update -y \
+  && yum remove -y postgresql \
+  && yum install -y postgresql96 postgresql96-devel postgresql96-libs \
+  && yum clean all \
+  && rm -rf /var/cache/yum
+
 RUN source ${APP_ROOT}/etc/scl_enable \
  && gem install bundler --version=2.0.1 --no-document
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN source ${APP_ROOT}/etc/scl_enable \
 
 COPY Gemfile* ./
 RUN source ${APP_ROOT}/etc/scl_enable \
- && bundle install --deployment --path vendor/bundle --jobs $(grep -c processor /proc/cpuinfo) --retry 3
+  && bundle config build.pg --with-pg-config=/usr/pgsql-9.6/bin/pg_config \
+  && bundle install --deployment --path vendor/bundle --jobs $(grep -c processor /proc/cpuinfo) --retry 3
 COPY . .
 ENV RAILS_LOG_TO_STDOUT=1
 USER root


### PR DESCRIPTION
Amazon Web Services no longer supports PostgreSQL 9.2, that reached End-of-Life in September, 2017. 

This PRs updates the PostgreSQL version by using the oficial PostgreSQL repository.