### PR TITLE
Revert "Route termination options follow public url scheme"

### DIFF
--- a/app/services/integration/kubernetes_service.rb
+++ b/app/services/integration/kubernetes_service.rb
@@ -135,19 +135,18 @@ class Integration::KubernetesService < Integration::ServiceBase
   class RouteSpec < K8s::Resource
     def initialize(url, service, port)
       uri = URI(url)
-      tls_options = {
-        insecureEdgeTerminationPolicy: 'Redirect',
-        termination: 'edge'
-      } if uri.class == URI::HTTPS
-
       super({
         host: uri.host || uri.path,
         port: { targetPort: port },
+        tls: {
+          insecureEdgeTerminationPolicy: 'Redirect',
+          termination: 'edge'
+        },
         to: {
           kind: 'Service',
           name: service
         }
-      }.merge(tls: tls_options))
+      })
     end
   end
 

--- a/test/services/kubernetes_service_test.rb
+++ b/test/services/kubernetes_service_test.rb
@@ -66,33 +66,4 @@ class Integration::KubernetesServiceTest < ActiveSupport::TestCase
 
     service.call(proxy)
   end
-
-  class RouteSpec < ActiveSupport::TestCase
-    test 'secure routes' do
-      url = 'https://my-api.example.com'
-      service_name = 'My API'
-      port = 7443
-      spec = Integration::KubernetesService::RouteSpec.new(url, service_name, port)
-      json = {
-        host: "my-api.example.com",
-        port: {targetPort: 7443},
-        to: {kind: "Service", name: "My API"},
-        tls: {insecureEdgeTerminationPolicy: "Redirect", termination: "edge"}
-      }
-      assert_equal json, spec.to_hash
-
-
-      url = 'http://my-api.example.com'
-      service_name = 'My API'
-      port = 7780
-      spec = Integration::KubernetesService::RouteSpec.new(url, service_name, port)
-      json = {
-        host: "my-api.example.com",
-        port: {targetPort: 7780},
-        to: {kind: "Service", name: "My API"},
-        tls: nil
-      }
-      assert_equal json, spec.to_hash
-    end
-  end
 end


### PR DESCRIPTION
Reverts 3scale/zync#265 (except unrelated changes)

OpenShift insecure routes are incompatible with Rails's `force_ssl`, enforced by [3scale/porta](https://github.com/3scale/porta) at https://github.com/3scale/porta/blob/c67d5d8227a1f64c0ff2c0d91f5ea39a00cb9fb9/openshift/system/config/settings.yml#L5

Reverting the changes is just an emergencial measure. The proper way to fix this would be in [3scale/porta](https://github.com/3scale/porta) by making sure the route is communicated to zync as an https route.