### PR TITLE
Default Kubernetes routes to https when the scheme is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 .byebug_history
 
 openshift.local.clusterup
+.ruby-version

--- a/app/services/integration/kubernetes_service.rb
+++ b/app/services/integration/kubernetes_service.rb
@@ -138,7 +138,7 @@ class Integration::KubernetesService < Integration::ServiceBase
       tls_options = {
         insecureEdgeTerminationPolicy: 'Redirect',
         termination: 'edge'
-      } if uri.class == URI::HTTPS
+      } if uri.class == URI::HTTPS || uri.scheme.blank?
 
       super({
         host: uri.host || uri.path,

--- a/test/services/kubernetes_service_test.rb
+++ b/test/services/kubernetes_service_test.rb
@@ -81,7 +81,6 @@ class Integration::KubernetesServiceTest < ActiveSupport::TestCase
       }
       assert_equal json, spec.to_hash
 
-
       url = 'http://my-api.example.com'
       service_name = 'My API'
       port = 7780
@@ -91,6 +90,20 @@ class Integration::KubernetesServiceTest < ActiveSupport::TestCase
         port: {targetPort: 7780},
         to: {kind: "Service", name: "My API"},
         tls: nil
+      }
+      assert_equal json, spec.to_hash
+    end
+
+    test 'defaults to https when scheme is missing' do
+      url = 'my-api.example.com'
+      service_name = 'My API'
+      port = 7443
+      spec = Integration::KubernetesService::RouteSpec.new(url, service_name, port)
+      json = {
+        host: "my-api.example.com",
+        port: {targetPort: 7443},
+        to: {kind: "Service", name: "My API"},
+        tls: {insecureEdgeTerminationPolicy: "Redirect", termination: "edge"}
       }
       assert_equal json, spec.to_hash
     end


### PR DESCRIPTION
This is the default case of Porta account routes, which [don't accept non-TLS routes on OpenShift](https://github.com/3scale/porta/blob/933da0da4b12d1296e4960b83ca60f3f2af07f68/openshift/system/config/settings.yml#L5), yet the API returns scheme-less provider domains (`domain` and `admin_domain`).

Closes [THREESCALE-4832](https://issues.redhat.com/browse/THREESCALE-4832)

Alternative to https://github.com/3scale/zync/pull/315.