### PR TITLE
[do not merge] Default Kubernetes routes to http when the scheme is missing

### DIFF
--- a/app/services/integration/kubernetes_service.rb
+++ b/app/services/integration/kubernetes_service.rb
@@ -181,17 +181,18 @@ class Integration::KubernetesService < Integration::ServiceBase
 
   def build_provider_routes(entry)
     data = entry.data
-    domain, admin_domain = data.values_at('domain', 'admin_domain')
+    domain = data.fetch('base_url', data.fetch('domain'))
+    admin_domain = data.fetch('admin_base_url', data.fetch('admin_domain'))
     metadata = { labels: labels_for_provider(entry), annotations: annotations_for(entry) }
 
     if admin_domain == domain # master account
       build_routes('zync-3scale-master-', [
-                     RouteSpec.new(data.fetch('domain'), 'system-master', 'http')
+                     RouteSpec.new(domain, 'system-master', 'http')
                    ], **metadata)
     else
       build_routes('zync-3scale-provider-', [
-                     RouteSpec.new(data.fetch('domain'), 'system-developer', 'http'),
-                     RouteSpec.new(data.fetch('admin_domain'), 'system-provider', 'http')
+                     RouteSpec.new(domain, 'system-developer', 'http'),
+                     RouteSpec.new(admin_domain, 'system-provider', 'http')
                    ], **metadata)
     end
   end

--- a/app/services/integration/kubernetes_service.rb
+++ b/app/services/integration/kubernetes_service.rb
@@ -138,7 +138,7 @@ class Integration::KubernetesService < Integration::ServiceBase
       tls_options = {
         insecureEdgeTerminationPolicy: 'Redirect',
         termination: 'edge'
-      } if uri.class == URI::HTTPS || uri.scheme.blank?
+      } if uri.class == URI::HTTPS
 
       super({
         host: uri.host || uri.path,

--- a/test/services/kubernetes_service_test.rb
+++ b/test/services/kubernetes_service_test.rb
@@ -94,7 +94,7 @@ class Integration::KubernetesServiceTest < ActiveSupport::TestCase
       assert_equal json, spec.to_hash
     end
 
-    test 'defaults to https when scheme is missing' do
+    test 'defaults to http when scheme is missing' do
       url = 'my-api.example.com'
       service_name = 'My API'
       port = 7443
@@ -103,7 +103,7 @@ class Integration::KubernetesServiceTest < ActiveSupport::TestCase
         host: "my-api.example.com",
         port: {targetPort: 7443},
         to: {kind: "Service", name: "My API"},
-        tls: {insecureEdgeTerminationPolicy: "Redirect", termination: "edge"}
+        tls: nil
       }
       assert_equal json, spec.to_hash
     end


### PR DESCRIPTION
Rolls back https://github.com/3scale/zync/pull/321 and relies on the new API attributes `base_url` and `admin_base_url` [just introduced in the 3scale Admin API](https://github.com/3scale/porta/pull/1869).

:warning: _Attention!_
Do not merge it until https://github.com/3scale/porta/pull/1869 is merged and deployed, otherwise it will just roll back https://github.com/3scale/zync/pull/321 and reopen [THREESCALE-4832](https://issues.redhat.com/browse/THREESCALE-4832).