### PR TITLE
Use UBI base image when building in Openshift

### DIFF
--- a/openshift/02-ruby-25-ubi7-imagestream.yml
+++ b/openshift/02-ruby-25-ubi7-imagestream.yml
@@ -3,12 +3,12 @@ kind: ImageStream
 metadata:
   labels:
     app: zync
-  name: ruby-24-centos7
+  name: ruby-25-ubi7
 spec:
   tags:
   - from:
       kind: DockerImage
-      name: centos/ruby-24-centos7
+      name: registry.access.redhat.com/ubi7/ruby-25
     name: latest
     referencePolicy:
       type: Source

--- a/openshift/03-buildconfig-template.yml
+++ b/openshift/03-buildconfig-template.yml
@@ -28,7 +28,7 @@ objects:
       dockerStrategy:
         from:
           kind: ImageStreamTag
-          name: ruby-24-centos7:latest
+          name: ruby-25-ubi7:latest
       type: Docker
     triggers:
     - github:
@@ -36,7 +36,7 @@ objects:
       type: GitHub
     - type: ImageChange
     - type: ConfigChange
- 
+
 parameters:
 - name: GITHUB_SECRET
   displayName: GitHub WebHook Secret


### PR DESCRIPTION
This PR changes the ImageStream and BuildConfig YAML templates offered as examples to build zync from source on Openshift (s2i). Instead of using centos7 as base image, it uses UBI7 Ruby 2.5 image, i.e. same one of the Dockerfile.