### PR TITLE
Removes the flag chown from COPY commands for backward compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,20 @@ WORKDIR ${APP_ROOT}
 RUN source ${APP_ROOT}/etc/scl_enable \
   && gem install bundler --version=2.0.1 --no-document
 
-COPY --chown=default:root Gemfile* ./
+USER root
+COPY Gemfile* ./
+RUN chown -fR default:root ./Gemfile
+
+USER default
 RUN source ${APP_ROOT}/etc/scl_enable \
   && bundle config build.pg --with-pg-config=/usr/pgsql-10/bin/pg_config \
   && bundle install --deployment --path vendor/bundle --jobs $(grep -c processor /proc/cpuinfo) --retry 3
 
-COPY --chown=default:root . .
+USER root
+COPY . .
+RUN chown -fR default:root .
 
+USER default
 ENV RAILS_LOG_TO_STDOUT=1
 RUN source ${APP_ROOT}/etc/scl_enable \
   && bundle exec bin/rails server -e production -d; \


### PR DESCRIPTION
`--chown` was introduced in Docker v17.09 and won't work in previous versions, failing to build the image for example in older Openshift clusters.

This significantly increases the size of the image built from 719MB to 846MB. We could mitigate this effect a little by changing the order of steps in the Dockerfile therefore creating less layers. The downside of it is that we might be running useless heavy steps such as `COPY . .` (followed by `chown`) in cases where `RUN bundle install --deployment` fails for example.