### PR TITLE
New Que stats Prometheus metrics

### DIFF
--- a/lib/prometheus/que_stats.rb
+++ b/lib/prometheus/que_stats.rb
@@ -17,8 +17,8 @@ module Prometheus
       end
     end
 
-    def job_stats(filter = nil)
-      filter = "WHERE #{filter}" if filter
+    def job_stats(*filters)
+      filter = "WHERE #{filters.join(' AND ')}" if filters.presence
       sql = <<~SQL
         SELECT args->0->>'job_class' AS job_class, COUNT(*) as count
         FROM que_jobs #{filter}
@@ -28,6 +28,26 @@ module Prometheus
       execute do |connection|
         connection.select_all(sql)
       end
+    end
+
+    def job_stats_ready
+      job_stats('error_count = 0', 'expired_at IS NULL', 'finished_at IS NULL', 'run_at <= now()')
+    end
+
+    def job_stats_scheduled
+      job_stats('run_at > now()')
+    end
+
+    def job_stats_finished
+      job_stats('finished_at IS NOT NULL')
+    end
+
+    def job_stats_retried
+      job_stats(%q[(args->0->>'retries')::integer > 0])
+    end
+
+    def job_stats_failed
+      job_stats('error_count > 0')
     end
 
     mattr_accessor :read_only_transaction, default: true, instance_accessor: false
@@ -54,23 +74,17 @@ end
 Yabeda.configure do
   group :que do
     scheduled_jobs = gauge :jobs_scheduled_total, comment: 'Que Jobs to be executed'
-    workers = gauge :workers_total,  comment: 'Que Workers running'
+    workers = gauge :workers_total, comment: 'Que Workers running'
+
+    set_stats = ->(type, stats) { scheduled_jobs.set({ job: stats.fetch('job_class') }.merge(type), stats.fetch('count')) }
 
     collect do
-      Prometheus::QueStats.job_stats.each do |stats|
-        scheduled_jobs.set({ job: stats.fetch('job_class') }, stats.fetch('count'))
-      end
+      set_stats_all = set_stats.curry.call({})
+      Prometheus::QueStats.job_stats.each(&set_stats_all)
 
-      Prometheus::QueStats.job_stats(%q[(args->0->>'retries')::integer > 0]).each do |stats|
-        scheduled_jobs.set({ job: stats.fetch('job_class'), type: 'retry' }, stats.fetch('count'))
-      end
-
-      Prometheus::QueStats.job_stats('run_at < now()').each do |stats|
-        scheduled_jobs.set({ job: stats.fetch('job_class'), type: 'scheduled' }, stats.fetch('count'))
-      end
-
-      Prometheus::QueStats.job_stats('run_at > now()').each do |stats|
-        scheduled_jobs.set({ job: stats.fetch('job_class'), type: 'future' }, stats.fetch('count'))
+      %w[ready scheduled finished retried failed].each do |type|
+        set_stats_type = set_stats.curry.call(type: type)
+        Prometheus::QueStats.public_send("job_stats_#{type}").each(&set_stats_type)
       end
 
       workers.set({ }, Prometheus::QueStats.worker_stats.fetch('workers'))

--- a/test/lib/prometheus/que_stats_test.rb
+++ b/test/lib/prometheus/que_stats_test.rb
@@ -17,8 +17,67 @@ class Prometheus::QueStatsTest < ActiveSupport::TestCase
   end
 
   test 'job stats' do
-    assert Prometheus::QueStats.job_stats
-    assert Prometheus::QueStats.job_stats('1 > 0')
+    Que.stop!
+    ApplicationJob.perform_later
+    assert Prometheus::QueStats.job_stats.any?
+    assert Prometheus::QueStats.job_stats('1 > 0').any?
+    assert Prometheus::QueStats.job_stats('1 > 0', '2 > 1').any?
+    assert Prometheus::QueStats.job_stats('1 > 0', '2 < 1').empty?
+  end
+
+  test 'ready jobs stats' do
+    Que.stop!
+    assert Prometheus::QueStats.job_stats_ready.empty?
+    jobs = Array.new(3) { ApplicationJob.perform_later }
+    jobs << ApplicationJob.set(wait_until: 1.day.from_now).perform_later
+    assert_equal 3, Prometheus::QueStats.job_stats_ready.first['count']
+    update_job(jobs[0], error_count: 1)
+    assert_equal 2, Prometheus::QueStats.job_stats_ready.first['count']
+    update_job(jobs[1], expired_at: 1.minute.ago)
+    assert_equal 1, Prometheus::QueStats.job_stats_ready.first['count']
+    update_job(jobs[2], finished_at: 1.minute.ago)
+    assert Prometheus::QueStats.job_stats_ready.empty?
+  end
+
+  test 'scheduled jobs stats' do
+    Que.stop!
+    assert Prometheus::QueStats.job_stats_scheduled.empty?
+    jobs = [ApplicationJob, ApplicationJob.set(wait_until: 1.day.from_now)].map(&:perform_later)
+    assert_equal 1, Prometheus::QueStats.job_stats_scheduled.first['count']
+    update_job(jobs.last, run_at: 1.minute.ago)
+    assert Prometheus::QueStats.job_stats_scheduled.empty?
+  end
+
+  test 'finished jobs stats' do
+    Que.stop!
+    assert Prometheus::QueStats.job_stats_finished.empty?
+    jobs = Array.new(2) { ApplicationJob.perform_later }
+    assert Prometheus::QueStats.job_stats_finished.empty?
+    update_job(jobs.first, finished_at: Time.now)
+    assert_equal 1, Prometheus::QueStats.job_stats_finished.first['count']
+  end
+
+  test 'retried jobs stats' do
+    Que.stop!
+    assert Prometheus::QueStats.job_stats_retried.empty?
+    jobs = Array.new(2) { ApplicationJob.perform_later }
+    assert Prometheus::QueStats.job_stats_retried.empty?
+
+    job = jobs.first
+    job_model = ApplicationJob.model.where("args->0->>'job_id' = ?", job.job_id).first
+    job_model.args = [job_model.args.first.merge('retries' => 1)]
+    job_model.save!
+
+    assert_equal 1, Prometheus::QueStats.job_stats_retried.first['count']
+  end
+
+  test 'failed jobs stats' do
+    Que.stop!
+    assert Prometheus::QueStats.job_stats_failed.empty?
+    jobs = Array.new(2) { ApplicationJob.perform_later }
+    assert Prometheus::QueStats.job_stats_failed.empty?
+    update_job(jobs.first, error_count: 1)
+    assert_equal 1, Prometheus::QueStats.job_stats_failed.first['count']
   end
 
   class WithTransaction < ActiveSupport::TestCase
@@ -45,5 +104,11 @@ class Prometheus::QueStatsTest < ActiveSupport::TestCase
     Yabeda.collectors.each(&:call)
 
     assert Prometheus::Client::Formats::Text.marshal(Yabeda::Prometheus.registry)
+  end
+
+  protected
+
+  def update_job(job, attributes = {})
+    ApplicationJob.model.where("args->0->>'job_id' = ?", job.job_id).update_all(attributes)
   end
 end


### PR DESCRIPTION
- Renames the following measurement types of the `jobs_scheduled_total` Prometheus (gauge) metric:
  - `<job_class>/retry` to `<job_class>/retried` (Que jobs with at least 1 retry attempt)
  - `<job_class>/future` to `<job_class>/scheduled` (Que jobs scheduled to be executed in the future)

- Introduces the following new measurement types of the `jobs_scheduled_total` Prometheus (gauge) metric:
  - `<job_class>/ready`: Que jobs ready to be executed for the first time (excludes: errored, expired, finished, performed)
  - `<job_class>/finished`: Que jobs already performed
  - `<job_class>/failed`: Que jobs that failed at least once

Related to https://github.com/3scale/infrastructure/issues/905