### PR TITLE
Make types of Que jobs Prometheus metrics exclusive

### DIFF
--- a/lib/prometheus/que_stats.rb
+++ b/lib/prometheus/que_stats.rb
@@ -89,7 +89,7 @@ module Prometheus
       end
 
       def failed
-        call(['error_count > ?', 0])
+        call(['error_count > ?', 0], { expired_at: nil })
       end
 
       def expired

--- a/lib/prometheus/que_stats.rb
+++ b/lib/prometheus/que_stats.rb
@@ -96,6 +96,10 @@ module Prometheus
         call(['error_count > ?', 0])
       end
 
+      def expired
+        call('expired_at IS NOT NULL')
+      end
+
       protected
 
       # ApplicationJob did not have to be here, but it's just harder to test otherwise because of ApplicationJob#delete_duplicates
@@ -177,7 +181,7 @@ Yabeda.configure do
     collector = Prometheus::QueStats::GroupedStatsCollector.new(jobs, job_stats, grouped_by: 'job')
     collect do
       collector.call
-      %w[ready scheduled finished retried failed].each(&collector.method(:call))
+      %w[ready scheduled finished retried failed expired].each(&collector.method(:call))
     end
   end
 end

--- a/lib/prometheus/que_stats.rb
+++ b/lib/prometheus/que_stats.rb
@@ -81,7 +81,7 @@ module Prometheus
       end
 
       def scheduled
-        call(['run_at > ?', Time.zone.now])
+        call(['error_count = ?', 0], ['run_at > ?', Time.zone.now])
       end
 
       def finished

--- a/lib/prometheus/que_stats.rb
+++ b/lib/prometheus/que_stats.rb
@@ -76,12 +76,11 @@ module Prometheus
       alias_method :all, :call
 
       def ready
-        conditions = [['error_count = ?', 0], { expired_at: nil, finished_at: nil }, ['run_at <= ?', Time.zone.now]]
-        call(*conditions)
+        call(['error_count = ?', 0], { expired_at: nil, finished_at: nil }, ['run_at <= ?', Time.zone.now])
       end
 
       def scheduled
-        call(['error_count = ?', 0], ['run_at > ?', Time.zone.now])
+        call(['error_count = ?', 0], { expired_at: nil, finished_at: nil }, ['run_at > ?', Time.zone.now])
       end
 
       def finished
@@ -89,7 +88,7 @@ module Prometheus
       end
 
       def failed
-        call(['error_count > ?', 0], { expired_at: nil })
+        call(['error_count > ?', 0], { expired_at: nil, finished_at: nil })
       end
 
       def expired

--- a/lib/prometheus/que_stats.rb
+++ b/lib/prometheus/que_stats.rb
@@ -88,10 +88,6 @@ module Prometheus
         call('finished_at IS NOT NULL')
       end
 
-      def retried
-        call(["(args->0->>'retries')::integer > ?", 0])
-      end
-
       def failed
         call(['error_count > ?', 0])
       end
@@ -181,7 +177,7 @@ Yabeda.configure do
     collector = Prometheus::QueStats::GroupedStatsCollector.new(jobs, job_stats, grouped_by: 'job')
     collect do
       collector.call
-      %w[ready scheduled finished retried failed expired].each(&collector.method(:call))
+      %w[ready scheduled finished failed expired].each(&collector.method(:call))
     end
   end
 end

--- a/test/lib/prometheus/que_stats_test.rb
+++ b/test/lib/prometheus/que_stats_test.rb
@@ -66,6 +66,10 @@ class Prometheus::QueStatsTest < ActiveSupport::TestCase
     assert_equal 0, stats_count(type: :failed)
     update_job(jobs.first, error_count: 1)
     assert_equal 1, stats_count(type: :failed)
+    update_job(jobs.first, error_count: 15)
+    assert_equal 1, stats_count(type: :failed)
+    update_job(jobs.first, error_count: 16, expired_at: Time.now.utc)
+    assert_equal 0, stats_count(type: :failed)
   end
 
   test 'expired jobs stats' do

--- a/test/lib/prometheus/que_stats_test.rb
+++ b/test/lib/prometheus/que_stats_test.rb
@@ -80,6 +80,15 @@ class Prometheus::QueStatsTest < ActiveSupport::TestCase
     assert_equal 1, stats_count(type: :failed)
   end
 
+  test 'expired jobs stats' do
+    Que.stop!
+    assert_equal 0, stats_count(type: :expired)
+    jobs = Array.new(2) { ApplicationJob.perform_later }
+    assert_equal 0, stats_count(type: :expired)
+    update_job(jobs.first, error_count: 16, expired_at: Time.now.utc)
+    assert_equal 1, stats_count(type: :expired)
+  end
+
   class WithTransaction < ActiveSupport::TestCase
     uses_transaction :test_readonly_transaction
     def test_readonly_transaction

--- a/test/lib/prometheus/que_stats_test.rb
+++ b/test/lib/prometheus/que_stats_test.rb
@@ -42,7 +42,9 @@ class Prometheus::QueStatsTest < ActiveSupport::TestCase
   test 'scheduled jobs stats' do
     Que.stop!
     assert_equal 0, stats_count(type: :scheduled)
-    jobs = [ApplicationJob, ApplicationJob.set(wait_until: 1.day.from_now)].map(&:perform_later)
+    jobs = [ApplicationJob, ApplicationJob.set(wait_until: 1.day.from_now), ApplicationJob.set(wait_until: 2.days.from_now)].map(&:perform_later)
+    assert_equal 2, stats_count(type: :scheduled)
+    update_job(jobs[1], error_count: 16, expired_at: 1.minute.ago)
     assert_equal 1, stats_count(type: :scheduled)
     update_job(jobs.last, run_at: 1.minute.ago)
     assert_equal 0, stats_count(type: :scheduled)

--- a/test/lib/prometheus/que_stats_test.rb
+++ b/test/lib/prometheus/que_stats_test.rb
@@ -59,20 +59,6 @@ class Prometheus::QueStatsTest < ActiveSupport::TestCase
     assert_equal 1, stats_count(type: :finished)
   end
 
-  test 'retried jobs stats' do
-    Que.stop!
-    assert_equal 0, stats_count(type: :retried)
-    jobs = Array.new(2) { ApplicationJob.perform_later }
-    assert_equal 0, stats_count(type: :retried)
-
-    job = jobs.first
-    job_model = ApplicationJob.model.where("args->0->>'job_id' = ?", job.job_id).first
-    job_model.args = [job_model.args.first.merge('retries' => 1)]
-    job_model.save!
-
-    assert_equal 1, stats_count(type: :retried)
-  end
-
   test 'failed jobs stats' do
     Que.stop!
     assert_equal 0, stats_count(type: :failed)


### PR DESCRIPTION
Redefines the types of Prometheus metrics on Que jobs (`que_jobs_scheduled_total`) as the following:

| Type      | Meaning                                                                                                                            |
|-----------|------------------------------------------------------------------------------------------------------------------------------------|
| ready     | Number of jobs enqueued and ready to be executed ASAP (never failed, nor got expired)                                              |
| scheduled | Number of jobs enqueued to be executed some time in the future, but not now (never failed, nor got expired)                        |
| finished  | Number of jobs that executed with success                                                                                          |
| failed    | Number of jobs that failed at least once, did not run out of attempts to retry and therefore are scheduled for retry any time soon |
| expired   | Number of jobs that failed and ran out of attempts to retry, therefore won't be retried again                                      |

Considering current implementation in Zync, `scheduled` and `finished` are expected to be always zero. The former because Zync does not make any job to "wait until" except when handling retries of failed jobs. The latter because Zync only keeps in the database the executed jobs that fail; whenever succeeded, they are deleted.

`que_jobs_scheduled_total{type="scheduled"}` does not correspond to Que's definition of "scheduled" (as showed in the Que's web console). Que defines "scheduled" as virtually a synonym of "enqueued". Every jobs scheduled to be executed, now or some time in the future, will be listed as "scheduled" by Que. In fact, even "expired" jobs may be listed as "scheduled" by Que. Whereas for the metric, we do a clear distinction between "ready" (now), "scheduled" (to some time in the future) and "expired", with unambiguous meaning to each one of these terms.

Moreover, `ready` is also expected to be zero most of time. If it's not zero, it's because Zync if nor processing the jobs or not processing them fast enough.

----

Closes [THREESCALE-5460](https://issues.redhat.com/browse/THREESCALE-5460)