### PR TITLE
Bump example rest-api's rack to 2.2.3

### DIFF
--- a/examples/rest-api/Gemfile.lock
+++ b/examples/rest-api/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    rack (2.0.7)
+    rack (2.2.3)
     rack-protection (2.0.5)
       rack
     sinatra (2.0.5)
@@ -29,4 +29,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   2.0.1
+   2.1.4


### PR DESCRIPTION
This does not affect Zync itself, but will prevent dependabot from raising security issues related to the example rest-api app that is part of zync's code base.