### PR TITLE
Fix race condition between entry jobs trying to create same proxy integration

### DIFF
--- a/app/jobs/process_entry_job.rb
+++ b/app/jobs/process_entry_job.rb
@@ -13,18 +13,20 @@ class ProcessEntryJob < ApplicationJob
   end
 
   def self.model_integrations_for(entry)
+    self.ensure_integrations_for(entry)
+
     model = entry.model
-
-    integrations = Integration.retry_record_not_unique do
-      case model.record
-      when Proxy then self.const_get(:PROXY_INTEGRATIONS).map { |i| i.new(entry) }.each(&:call)
-      when Provider then CreateK8SIntegration.new(entry).call
-      end
-
-      Integration.for_model(model)
-    end
-
+    integrations = Integration.for_model(model)
     integrations.each.with_object(model)
+  end
+
+  def self.ensure_integrations_for(entry)
+    case entry.model.record
+    when Proxy
+      self.const_get(:PROXY_INTEGRATIONS).map { |integration| integration.new(entry) }.each(&:call)
+    when Provider
+      CreateK8SIntegration.new(entry).call
+    end
   end
 
   protected
@@ -94,7 +96,7 @@ class ProcessEntryJob < ApplicationJob
       return unless enabled?
 
       transaction do
-        integration = integrations.find_or_create_by!(type: integration_type.to_s)
+        integration = integrations.create_or_find_by!(type: integration_type.to_s)
         integration.update(state: Integration.states.fetch(:active))
 
         ProcessIntegrationEntryJob.perform_later(integration, model)
@@ -153,7 +155,7 @@ class ProcessEntryJob < ApplicationJob
     def find_integration
       model
         .create_with(endpoint: endpoint)
-        .find_or_create_by!(integrations.where_values_hash)
+        .create_or_find_by!(integrations.where_values_hash)
     end
   end
 

--- a/app/jobs/process_entry_job.rb
+++ b/app/jobs/process_entry_job.rb
@@ -17,7 +17,7 @@ class ProcessEntryJob < ApplicationJob
 
     integrations = Integration.retry_record_not_unique do
       case model.record
-      when Proxy then PROXY_INTEGRATIONS.map { |i| i.new(entry) }.each(&:call)
+      when Proxy then self.const_get(:PROXY_INTEGRATIONS).map { |i| i.new(entry) }.each(&:call)
       when Provider then CreateK8SIntegration.new(entry).call
       end
 

--- a/config/initializers/rails_6.rb
+++ b/config/initializers/rails_6.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Remove this when upgrading to Rails 6
+module Rails6
+  module ActiveRecord
+    module Relation
+      # File activerecord/lib/active_record/relation.rb, line 218
+      def create_or_find_by!(attributes, &block)
+        transaction(requires_new: true) { create!(attributes, &block) }
+      rescue ::ActiveRecord::RecordNotUnique
+        find_by!(attributes)
+      end
+
+      # File activerecord/lib/active_record/relation.rb, line 209
+      def create_or_find_by(attributes, &block)
+        transaction(requires_new: true) { create(attributes, &block) }
+      rescue ::ActiveRecord::RecordNotUnique
+        find_by!(attributes)
+      end
+    end
+  end
+end
+
+ActiveRecord::Relation.prepend(Rails6::ActiveRecord::Relation)

--- a/test/jobs/process_entry_job_test.rb
+++ b/test/jobs/process_entry_job_test.rb
@@ -67,7 +67,7 @@ class ProcessEntryJobTest < ActiveJob::TestCase
   end
 
   class ProcessEntryJobWithFiber < ProcessEntryJob
-    PROXY_INTEGRATIONS = [CreateProxyIntegrationWithFiber]
+    self.proxy_integration_services = [CreateProxyIntegrationWithFiber]
   end
 
   test 'race condition between entry jobs to create same proxy integration' do

--- a/test/jobs/process_entry_job_test.rb
+++ b/test/jobs/process_entry_job_test.rb
@@ -59,23 +59,10 @@ class ProcessEntryJobTest < ActiveJob::TestCase
     end
   end
 
-  class ActiveRecordRelationWithFiber < ActiveRecord::Relation
-    def find_by(*attributes)
-      record = super
-      Fiber.yield
-      record
-    end
-  end
-
-  class IntegrationWithFiber < ::Integration::REST
-    def self.relation
-      ActiveRecordRelationWithFiber.new(self)
-    end
-  end
-
   class CreateProxyIntegrationWithFiber < ProcessEntryJob::CreateOIDCProxyIntegration
-    def model
-      IntegrationWithFiber
+    def find_integration
+      Fiber.yield
+      super
     end
   end
 
@@ -90,23 +77,19 @@ class ProcessEntryJobTest < ActiveJob::TestCase
     UpdateState.where(model: existing_integrations).delete_all
     existing_integrations.delete_all
 
-    fiber1 = Fiber.new { ProcessEntryJobWithFiber.model_integrations_for(entry) }
-    fiber2 = Fiber.new { ProcessEntryJobWithFiber.model_integrations_for(entry) }
+    fiber1 = Fiber.new { ProcessEntryJobWithFiber.ensure_integrations_for(entry) }
+    fiber2 = Fiber.new { ProcessEntryJobWithFiber.ensure_integrations_for(entry) }
 
     fiber1.resume
-    fiber2.resume # right now, both jobs believe the integration must be created
+    fiber2.resume
 
-    assert_difference(Integration.where(type: 'ProcessEntryJobTest::IntegrationWithFiber').method(:count)) do
+    assert_difference(existing_integrations.method(:count)) do
       fiber2.resume # creates the integration first
     end
 
-    old_logger = ::Integration.logger
-    tmp_logger = Minitest::Mock.new(old_logger)
-    ::Integration.logger = tmp_logger
-    tmp_logger.expect(:warn, true) { |error| ActiveRecord::RecordNotUnique === error }
-
-    fiber1.resume # raises ActiveRecord::RecordNotUnique
-    ::Integration.logger = old_logger
+    assert_no_difference(existing_integrations.method(:count)) do
+      fiber1.resume
+    end
   end
 
   test 'skips deleted proxy' do


### PR DESCRIPTION
`ApplicationRecord.retry_record_not_unique` returns `nil` when it fails with `ActiveRecord::RecordNotUnique` more than once, which can happen in case of a race condition involving 3+ jobs trying to process entries that maps to the same tenant/integration type. Particularly, this makes https://github.com/3scale/zync/blob/d1d6360de9064adcf5e0e3c7b810b381edc4a87a/app/jobs/process_entry_job.rb#L27 to fail with:

```ruby
NoMethodError: undefined method `each' for nil:NilClass
```

----

Closes [THREESCALE-5632](https://issues.redhat.com/browse/THREESCALE-5632)