### PR TITLE
3scale-2.9.0-CR1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
       erubis
       que (~> 1.0.0.beta3)
       sinatra
-    rack (2.2.2)
+    rack (2.2.3)
     rack-protection (2.0.5)
       rack
     rack-test (1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (3.1.1)
-    puma (4.3.3)
+    puma (4.3.5)
       nio4r (~> 2.0)
     quantile (0.2.1)
     que (1.0.0.beta3)

--- a/config/initializers/rails_6.rb
+++ b/config/initializers/rails_6.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Remove this when upgrading to Rails 6
+module Rails6
+  module ActiveRecord
+    module Relation
+      # File activerecord/lib/active_record/relation.rb, line 218
+      def create_or_find_by!(attributes, &block)
+        transaction(requires_new: true) { create!(attributes, &block) }
+      rescue ::ActiveRecord::RecordNotUnique
+        find_by!(attributes)
+      end
+
+      # File activerecord/lib/active_record/relation.rb, line 209
+      def create_or_find_by(attributes, &block)
+        transaction(requires_new: true) { create(attributes, &block) }
+      rescue ::ActiveRecord::RecordNotUnique
+        find_by!(attributes)
+      end
+    end
+  end
+end
+
+ActiveRecord::Relation.prepend(Rails6::ActiveRecord::Relation)

--- a/examples/rest-api/Gemfile.lock
+++ b/examples/rest-api/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    rack (2.0.7)
+    rack (2.2.3)
     rack-protection (2.0.5)
       rack
     sinatra (2.0.5)
@@ -29,4 +29,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   2.0.1
+   2.1.4


### PR DESCRIPTION
https://github.com/3scale/zync/pull/342 [Security] Bump rack from 2.2.2 to 2.2.3
https://github.com/3scale/zync/pull/337 [Security] Bump puma from 4.3.3 to 4.3.5
https://github.com/3scale/zync/pull/347 [Security] Bump example rest-api's rack to 2.2.3
https://github.com/3scale/zync/pull/348 Fix race condition between entry jobs trying to create same proxy integration ([THREESCALE-5632](https://issues.redhat.com/browse/THREESCALE-5632))