### PR TITLE
Adding activerecord-pg_enum gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'puma', '~> 5.2'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
+gem 'activerecord-pg_enum'
+
 gem 'responders', '~> 3.0.1'
 gem '3scale-api'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,10 @@ GEM
     activerecord (6.1.3)
       activemodel (= 6.1.3)
       activesupport (= 6.1.3)
+    activerecord-pg_enum (1.2.2)
+      activerecord (>= 4.1.0)
+      activesupport
+      pg
     activestorage (6.1.3)
       actionpack (= 6.1.3)
       activejob (= 6.1.3)
@@ -327,6 +331,7 @@ PLATFORMS
 
 DEPENDENCIES
   3scale-api
+  activerecord-pg_enum
   bootsnap (>= 1.4.4)
   bugsnag
   bugsnag-capistrano (< 2)

--- a/db/migrate/20190530080459_add_integration_state.rb
+++ b/db/migrate/20190530080459_add_integration_state.rb
@@ -1,6 +1,6 @@
 class AddIntegrationState < ActiveRecord::Migration[5.2]
   def up
-    create_enum :integration_state, 'active', 'disabled'
+    create_enum :integration_state, %w[active disabled]
     add_column :integrations, :state, :integration_state
     default = 'active'
     Integration.in_batches.update_all(state: default)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -37,8 +37,6 @@ $$;
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
-
 --
 -- Name: que_jobs; Type: TABLE; Schema: public; Owner: -
 --
@@ -264,8 +262,8 @@ ALTER SEQUENCE public.applications_id_seq OWNED BY public.applications.id;
 CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -1178,10 +1176,10 @@ CREATE INDEX index_metrics_on_tenant_id ON public.metrics USING btree (tenant_id
 
 
 --
--- Name: index_models_on_record_type_and_record_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_models_on_record; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_models_on_record_type_and_record_id ON public.models USING btree (record_type, record_id);
+CREATE UNIQUE INDEX index_models_on_record ON public.models USING btree (record_type, record_id);
 
 
 --


### PR DESCRIPTION
Adding ActiveRecord::PGEnum Gem to support `enum`

**Issue**
undefined method `create_enum' error while migrating in production

