### PR TITLE
Fix CVE 2020-3627

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ USER default
 WORKDIR ${APP_ROOT}
 
 RUN source ${APP_ROOT}/etc/scl_enable \
-  && gem install bundler --version=2.0.1 --no-document
+  && gem install bundler --version=2.2.19 --no-document
 
 COPY --chown=default:root Gemfile* ./
 RUN source ${APP_ROOT}/etc/scl_enable \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,4 +366,4 @@ DEPENDENCIES
   yabeda-rails
 
 BUNDLED WITH
-   2.2.15
+   2.2.19


### PR DESCRIPTION
Updating bundler to 2.2.19 to fix cve-2020-3627

Relates to #454

Refers to https://issues.redhat.com/browse/THREESCALE-7085
