### PR TITLE
Build latest image and push to quay.io as GH action

### DIFF
--- a/.github/workflows/quay-io-build-latest.yml
+++ b/.github/workflows/quay-io-build-latest.yml
@@ -1,0 +1,31 @@
+name: Build and push to quay.io the latest code
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Login to quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER_NAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            quay.io/3scale/zync:latest
+            quay.io/3scale/zync:nightly

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@
 
 openshift.local.clusterup
 .ruby-version
+.tool-versions


### PR DESCRIPTION
Zync should build its own image and push to quay.io/3scale/zync:latest

:warning: DEPRECATION `nightly` tag is deprecated
and will be removed without further notice after 3 months

@3scale/support @3scale/documentation @3scale/qe If any documentation mentions nightly build please correct it

We are for now going to keep nightly tag for backward compatibility but it will reference the latest build