### PR TITLE
Fix Kubernetes service finding from owner references without metadata

### DIFF
--- a/app/services/integration/kubernetes_service.rb
+++ b/app/services/integration/kubernetes_service.rb
@@ -53,9 +53,8 @@ class Integration::KubernetesService < Integration::ServiceBase
   def owner_reference_controller(resource)
     owner_references = resource.metadata.ownerReferences or return
     controller = owner_references.find(&:controller)
-    controller.metadata = { namespace: namespace, name: controller.name }
 
-    client.get_resource(controller)
+    client.get_resource(controller.merge(metadata: { namespace: namespace, name: controller.name }))
   end
 
   def owner_reference_root(resource)


### PR DESCRIPTION
Kubernetes `meta/v1.OwnerReference` resources do not contain a `metadata` field and therefore Zync's `Integration::KubernetesService#owner_reference_controller` should not expect the `OpenStruct` Ruby objects that represent those resources to respond to `#metadata` and then recursively to `#[]=(value)`. Doing such will result in 

```ruby
NoMethodError: undefined method `[]=' for nil:NilClass
```

However, https://github.com/kontena/k8s-client still expects any resource reference passed as argument to `K8s::Client#get_resource` to respond to `#metadata`. To set the `metadata` field on the owner reference resource, we need to use `K8s::Resource#merge`

Closes [THREESCALE-7283](https://issues.redhat.com/browse/THREESCALE-7283)