### PR TITLE
[gh-actions] Add workflow to create a candidate branch

### DIFF
--- a/.github/workflows/fast-forward-candidate-branch.yml
+++ b/.github/workflows/fast-forward-candidate-branch.yml
@@ -1,0 +1,28 @@
+name: Fast-forward candidate branch to HEAD of default branch
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'The release version number (e.g, 2.11)'
+        required: true
+      ref:
+        description: 'The SHA1 or branch name the candidate branch will point to'
+        required: true
+        default: origin/master
+
+jobs:
+  fast-forward:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: 3scale-${{ github.event.inputs.release }}-candidate
+          fetch-depth: 0
+          token: ${{ secrets.FF_CANDIDATE_BRANCH_PAT_TOKEN }}
+      - run: |
+            export candidate_branch="3scale-${{ github.event.inputs.release }}-candidate"
+            git checkout ${candidate_branch} && git pull ||  git checkout -b ${candidate_branch}
+            git merge ${{ github.event.inputs.ref }} --ff-only
+            git push origin ${candidate_branch}
+
+        name: Push to candidate branch


### PR DESCRIPTION
Uses a PAT token like in 3scale/porta