### PR TITLE
Fix circleci installed bundler version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,9 @@ jobs:
           name: bundle install
           command: |
             gem install bundler --version=$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tr -d ' '| tail -n 1)
-            bundle install --deployment --path vendor/bundle --jobs $(grep -c processor /proc/cpuinfo) --retry 3
+            bundle config set --local deployment 'true'
+            bundle config set --local path 'vendor/bundle'
+            bundle install --jobs $(grep -c processor /proc/cpuinfo) --retry 3
       - run:
           name: boot zync
           command: BUNDLE_WITHOUT=development:test bundle exec bin/rails runner --environment=production 'puts Rails.env'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
           name: bundle install
           command: |
             gem install bundler --version=$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tr -d ' '| tail -n 1)
+            bundle config --local force_ruby_platform true
             bundle config set --local deployment 'true'
             bundle config set --local path 'vendor/bundle'
             bundle install --jobs $(grep -c processor /proc/cpuinfo) --retry 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run:
           name: bundle install
           command: |
-            gem install bundler --version=2.0.1
+            gem install bundler --version=$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tr -d ' '| tail -n 1)
             bundle install --deployment --path vendor/bundle --jobs $(grep -c processor /proc/cpuinfo) --retry 3
       - run:
           name: boot zync


### PR DESCRIPTION
This will automatically install the correct version that is indicated in the Gemfile.lock file

Also fixes license_finder failing to execute