### PR TITLE
This PR enables s390x arch in TravisCI for zync.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 sudo: false
 dist: bionic
-arch: ppc64le
+arch:
+- ppc64le
+- s390x
 services:
   - postgresql
 


### PR DESCRIPTION
This PR enables s390x arch in TravisCI for zync.

Signed-off-by: Artiom Vaskov <artiom.vaskov@ibm.com>