### PR TITLE
Add BUGSNAG_RELEASE_STAGE to Bugsnag initializer

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,3 +1,4 @@
 Bugsnag.configure do |config|
   config.api_key = Rails.application.secrets.bugsnag_api_key
+  config.release_stage = ENV['BUGSNAG_RELEASE_STAGE'].presence || Rails.env
 end


### PR DESCRIPTION
Allows setting a `releaseStage` in Bugsnag which is different from `RAILS_ENV`.

For example, `RAILS_ENV` can be `production`, while it can be reported to Bugsnag as `staging`.