### PR TITLE
Backport fix to version of httpclient

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/3scale/httpclient.git
-  revision: fec23fb32fb899b87a8b2c94e2d2069b6b4c633c
+  revision: 779beabd653afcd03c4468e0a69dc043f3bbb748
   branch: ssl-env-cert
   specs:
     httpclient (2.8.3)


### PR DESCRIPTION
The latest commit wasn't picked up and this change is required for Cachito to be able to pick up this dependency correctly

(cherry picked from commit f13bee99fc358c11f289b2520486194189434be1)

