### PR TITLE
Upgrade que gem to v1.1.0 to fix deadlock issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,10 @@ RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/
 USER default
 WORKDIR ${APP_ROOT}
 
-RUN gem install bundler --version=2.3.25 --no-document
-
 COPY --chown=default:root Gemfile* ./
+
+RUN BUNDLER_VERSION=$(awk '/BUNDLED WITH/ { getline; print $1 }' Gemfile.lock) \
+    && gem install bundler --version=$BUNDLER_VERSION --no-document
 
 RUN bundle config build.pg --with-pg-config=/usr/pgsql-12/bin/pg_config \
   && bundle install --deployment --path vendor/bundle --jobs $(grep -c processor /proc/cpuinfo) --retry 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf --setopt=skip_missing_names_on_install=False,tsflags=nodocs --save \
 USER default
 WORKDIR ${APP_ROOT}
 
-RUN gem install bundler --version=2.2.19 --no-document
+RUN gem install bundler --version=2.3.25 --no-document
 
 COPY --chown=default:root Gemfile* ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 FROM registry.access.redhat.com/ubi8/ruby-27
 
 USER root
-RUN dnf --setopt=skip_missing_names_on_install=False,tsflags=nodocs --save \
-  && rpm -Uvh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
   && dnf update -y \
-  && dnf remove -y postgresql \
-  && dnf install -y shared-mime-info postgresql12 postgresql12-devel postgresql12-libs \
+  && dnf remove -y postgresql* \
+  && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs -y shared-mime-info postgresql12-12.13 postgresql12-devel-12.13 postgresql12-libs-12.13 \
   && dnf clean all \
   && rm -rf /var/cache/yum
 

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,9 @@ gem '3scale-api'
 
 gem 'bootsnap', '>= 1.4.4'
 
-gem 'que', '>= 1.0.0.beta3'
+# NOTE: do not upgrade to que v1.2 without upgrading Rails to v7, the deprecation introduced in 1.2.0 is resolved
+# in Rails >=7.0.4 https://github.com/rails/rails/blob/7-0-stable/activejob/CHANGELOG.md#rails-704-september-09-2022
+gem 'que', '~> 1.1.0'
 gem 'que-web'
 
 gem 'bugsnag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,9 +226,9 @@ GEM
     public_suffix (4.0.6)
     puma (5.2.1)
       nio4r (~> 2.0)
-    que (1.0.0.beta4)
-    que-web (0.9.3)
-      que (~> 1.0.0.beta3)
+    que (1.1.0)
+    que-web (0.10.0)
+      que (>= 1)
       sinatra
     racc (1.6.2)
     rack (2.2.6.2)
@@ -354,7 +354,7 @@ DEPENDENCIES
   pry-rescue
   pry-stack_explorer
   puma (~> 5.2)
-  que (>= 1.0.0.beta3)
+  que (~> 1.1.0)
   que-web
   rails (~> 6.1.7)
   responders (~> 3.0.1)


### PR DESCRIPTION
There is an epic "Zync doesn't create routes": https://issues.redhat.com/browse/THREESCALE-7657

While this may be caused by different reasons, it seems that in some cases restarting `zync-que` pod resolves the issue (e.g. https://issues.redhat.com/browse/THREESCALE-6835)

There are some common reports on the [que-rb](https://github.com/que-rb) repo reporting similar issues - workers just stop processing the job queue, specifically https://github.com/que-rb/que/issues/241 explains that there is some kind of a deadlock that causes this.

This (and other issues that may potentially cause deadlocks) is fixed in the version [1.0.0.beta5 (2021-12-23)|https://github.com/que-rb/que/blob/master/CHANGELOG.md#100beta5-2021-12-23], or in fact 1.0.0. The currently used version is `1.0.0.beta4`.

This PR upgrades `que` to `1.1.0` - it is the last version that does does not have any deprecations that would appear with the currently used Rails version. In order to upgrade to >= 1.2.0 and upgrade to Rails >= 7.0.4 is also recommended.