### PR TITLE
Fix CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     resource_class: small
     working_directory: /home/circleci/zync
     docker:
-      - image: circleci/buildpack-deps:latest
+      - image: cimg/base:current
         environment:
           POSGRES_CONTAINER_NAME: db
           DATABASE_URL: postgresql://postgres:postgres@db:5432/zync

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
     working_directory: /opt/app-root/zync
     docker:
       - image: registry.access.redhat.com/ubi7/ruby-27
-      - image: circleci/postgres:<< parameters.postgresql_version >>-ram
+      - image: cimg/postgres:<< parameters.postgresql_version >>
     environment:
         RAILS_ENV: test
         DISABLE_SPRING: 1 # we can't really run spring as it hangs on local circleci build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - setup_remote_docker
       - run: docker build --tag zync:build --file ./Dockerfile .
       - run: docker network create net0
-      - run: docker run --net net0 --name ${POSGRES_CONTAINER_NAME} -d -p 5432:5432 -e POSTGRES_USER=${POSTGRES_USER} -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -e POSTGRES_DB=${POSTGRES_DB} postgres:12-alpine
+      - run: docker run --net net0 --name ${POSGRES_CONTAINER_NAME} -d -p 5432:5432 -e POSTGRES_USER=${POSTGRES_USER} -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -e POSTGRES_DB=${POSTGRES_DB} postgres:13-alpine
       - run:
           command: |
             docker run --net net0 -e RAILS_ENV=${RAILS_ENV} -e DATABASE_URL=${DATABASE_URL} \
@@ -90,5 +90,5 @@ workflows:
       - build:
           matrix:
             parameters:
-              postgresql_version: [ "10-alpine", "12-alpine" ]
+              postgresql_version: [ "10-alpine", "13-alpine" ]
       - docker-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     docker:
       - image: cimg/base:current
         environment:
-          POSGRES_CONTAINER_NAME: db
+          POSTGRES_CONTAINER_NAME: db
           DATABASE_URL: postgresql://postgres:postgres@db:5432/zync
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -17,7 +17,7 @@ jobs:
       - setup_remote_docker
       - run: docker build --tag zync:build --file ./Dockerfile .
       - run: docker network create net0
-      - run: docker run --net net0 --name ${POSGRES_CONTAINER_NAME} -d -p 5432:5432 -e POSTGRES_USER=${POSTGRES_USER} -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -e POSTGRES_DB=${POSTGRES_DB} postgres:13-alpine
+      - run: docker run --net net0 --name ${POSTGRES_CONTAINER_NAME} -d -p 5432:5432 -e POSTGRES_USER=${POSTGRES_USER} -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -e POSTGRES_DB=${POSTGRES_DB} postgres:13-alpine
       - run:
           command: |
             docker run --net net0 -e RAILS_ENV=${RAILS_ENV} -e DATABASE_URL=${DATABASE_URL} \
@@ -25,12 +25,12 @@ jobs:
 
   build:
     parameters:
-      postgresql_version:
+      postgresql_image:
         type: string
     working_directory: /opt/app-root/zync
     docker:
-      - image: registry.access.redhat.com/ubi7/ruby-27
-      - image: cimg/postgres:<< parameters.postgresql_version >>
+      - image: registry.access.redhat.com/ubi8/ruby-27
+      - image: << parameters.postgresql_image >>
     environment:
         RAILS_ENV: test
         DISABLE_SPRING: 1 # we can't really run spring as it hangs on local circleci build
@@ -90,5 +90,5 @@ workflows:
       - build:
           matrix:
             parameters:
-              postgresql_version: [ "10-alpine", "13-alpine" ]
+              postgresql_image: [ "circleci/postgres:10-alpine-ram", "cimg/postgres:13.11" ]
       - docker-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
         type: string
     working_directory: /opt/app-root/zync
     docker:
-      - image: registry.access.redhat.com/ubi8/ruby-27
+      - image: registry.access.redhat.com/ubi7/ruby-27
       - image: << parameters.postgresql_image >>
     environment:
         RAILS_ENV: test

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER root
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
   && dnf update -y \
   && dnf remove -y postgresql* \
-  && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs -y shared-mime-info postgresql12-12.13 postgresql12-devel-12.13 postgresql12-libs-12.13 \
+  && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs -y shared-mime-info postgresql13 postgresql13-devel postgresql13-libs \
   && dnf clean all \
   && rm -rf /var/cache/yum
 
@@ -16,7 +16,7 @@ COPY --chown=default:root Gemfile* ./
 RUN BUNDLER_VERSION=$(awk '/BUNDLED WITH/ { getline; print $1 }' Gemfile.lock) \
     && gem install bundler --version=$BUNDLER_VERSION --no-document
 
-RUN bundle config build.pg --with-pg-config=/usr/pgsql-12/bin/pg_config \
+RUN bundle config build.pg --with-pg-config=/usr/pgsql-13/bin/pg_config \
   && bundle install --deployment --path vendor/bundle --jobs $(grep -c processor /proc/cpuinfo) --retry 3
 
 COPY --chown=default:root . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM registry.access.redhat.com/ubi8/ruby-27
 
 USER root
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
-  && dnf update -y \
-  && dnf remove -y postgresql* \
-  && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs -y shared-mime-info postgresql13 postgresql13-devel postgresql13-libs \
+  && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs --skip-broken -y shared-mime-info postgresql13 postgresql13-devel postgresql13-libs \
   && dnf clean all \
   && rm -rf /var/cache/yum
 


### PR DESCRIPTION
This PR does a few things:

- updates CircleCI base image, see https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034
- upgrades PostgreSQL image to 13. I don't know why there was 12 in the first place. [Supported Configurations](https://access.redhat.com/articles/2798521) doesn't specify what version of **external** PostgreSQL is supported for Zync, but it only mentions 13. The built-in database for Zync in 3scale operator is version 10, there is a JIRA to upgrade it:
[THREESCALE-8545: change support of PostgreSQL (internal db) from 10.x to 13.x](https://issues.redhat.com/browse/THREESCALE-8545)
- tweaks the Dockerfile to fix the failing build (see inline comments)