### PR TITLE
Upgrade Que to version 1.4 (prep for v2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
 
       - run:
           name: Set up the DB
-          command: bundle exec bin/rails db:wait db:reset
+          command: bundle exec bin/rails db:wait db:setup
 
       - run:
           name: rails test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,8 @@ jobs:
             - vendor/bundle
 
       - run:
-          name: rails db:setup
-          command: bundle exec bin/rails db:wait db:setup
+          name: Set up the DB
+          command: bundle exec bin/rails db:wait db:reset
 
       - run:
           name: rails test

--- a/Gemfile
+++ b/Gemfile
@@ -31,9 +31,7 @@ gem '3scale-api'
 
 gem 'bootsnap', '>= 1.4.4'
 
-# NOTE: do not upgrade to que v1.2 without upgrading Rails to v7, the deprecation introduced in 1.2.0 is resolved
-# in Rails >=7.0.4 https://github.com/rails/rails/blob/7-0-stable/activejob/CHANGELOG.md#rails-704-september-09-2022
-gem 'que', '~> 1.1.0'
+gem 'que', '1.4.1'
 gem 'que-web'
 
 gem 'bugsnag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
     public_suffix (4.0.6)
     puma (5.2.1)
       nio4r (~> 2.0)
-    que (1.1.0)
+    que (1.4.1)
     que-web (0.10.0)
       que (>= 1)
       sinatra
@@ -380,7 +380,7 @@ DEPENDENCIES
   pry-rescue
   pry-stack_explorer
   puma (~> 5.2)
-  que (~> 1.1.0)
+  que (= 1.4.1)
   que-web
   rails (~> 7.0.5)
   responders (~> 3.0.1)

--- a/db/migrate/20230629131935_update_que_tables_to_version5.rb
+++ b/db/migrate/20230629131935_update_que_tables_to_version5.rb
@@ -1,0 +1,8 @@
+class UpdateQueTablesToVersion5 < ActiveRecord::Migration[7.0]
+  def up
+    Que.migrate!(version: 5)
+  end
+  def down
+    Que.migrate!(version: 4)
+  end
+end

--- a/db/structure-10.sql
+++ b/db/structure-10.sql
@@ -54,6 +54,7 @@ CREATE TABLE public.que_jobs (
     expired_at timestamp with time zone,
     args jsonb DEFAULT '[]'::jsonb NOT NULL,
     data jsonb DEFAULT '{}'::jsonb NOT NULL,
+    job_schema_version integer DEFAULT 1,
     CONSTRAINT error_length CHECK (((char_length(last_error_message) <= 500) AND (char_length(last_error_backtrace) <= 10000))),
     CONSTRAINT job_class_length CHECK ((char_length(
 CASE job_class
@@ -71,7 +72,7 @@ WITH (fillfactor='90');
 -- Name: TABLE que_jobs; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON TABLE public.que_jobs IS '4';
+COMMENT ON TABLE public.que_jobs IS '5';
 
 
 --
@@ -121,7 +122,10 @@ CREATE FUNCTION public.que_job_notify() RETURNS trigger
         FROM (
           SELECT *
           FROM public.que_lockers ql, generate_series(1, ql.worker_count) AS id
-          WHERE listening AND queues @> ARRAY[NEW.queue]
+          WHERE
+            listening AND
+            queues @> ARRAY[NEW.queue] AND
+            ql.job_schema_version = NEW.job_schema_version
           ORDER BY md5(pid::text || id::text)
         ) t1
       ) t2
@@ -628,6 +632,7 @@ CREATE UNLOGGED TABLE public.que_lockers (
     ruby_hostname text NOT NULL,
     queues text[] NOT NULL,
     listening boolean NOT NULL,
+    job_schema_version integer DEFAULT 1,
     CONSTRAINT valid_queues CHECK (((array_ndims(queues) = 1) AND (array_length(queues, 1) IS NOT NULL))),
     CONSTRAINT valid_worker_priorities CHECK (((array_ndims(worker_priorities) = 1) AND (array_length(worker_priorities, 1) IS NOT NULL)))
 );
@@ -1274,6 +1279,13 @@ CREATE INDEX que_poll_idx ON public.que_jobs USING btree (queue, priority, run_a
 
 
 --
+-- Name: que_poll_idx_with_job_schema_version; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX que_poll_idx_with_job_schema_version ON public.que_jobs USING btree (job_schema_version, queue, priority, run_at, id) WHERE ((finished_at IS NULL) AND (expired_at IS NULL));
+
+
+--
 -- Name: table_added_at_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1510,6 +1522,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190530080459'),
 ('20190603140450'),
 ('20190605094424'),
-('20210504152609');
+('20210504152609'),
+('20230629131935');
 
 


### PR DESCRIPTION
Based on https://github.com/3scale/zync/pull/502

Gradual upgrade, based on the instructions here: https://github.com/que-rb/que/blob/master/CHANGELOG.md#200beta1-2022-03-24

>Recommended upgrade process:

>When using Que 2.x, a job enqueued with Ruby 2.7 will run as expected on Ruby 3. We recommend:

>Upgrade your project to the latest 1.x version of Que (1.3.1+)
IMPORTANT: adds support for zero downtime upgrade to Que 2.x, see changelog below
>Upgrade your project to Ruby 2.7 and Rails 6.x if it is not already
>Upgrade your project to Que 2.x but stay on Ruby 2.7
>IMPORTANT: You will need to continue to run Que 1.x workers until all jobs enqueued using Que 1.x (i.e. with a job_schema_version of 1) have been finished. See below
>Upgrade your project to Ruby 3

This is the first part, non-breaking, just adds a new column `job_schema_version` to the `que_jobs` table.