### PR TITLE
Add PostgreSQL 12 to tests and prevent from using unsupported versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,5 +90,5 @@ workflows:
       - build:
           matrix:
             parameters:
-              postgresql_image: [ "circleci/postgres:10-alpine-ram", "cimg/postgres:13.11" ]
+              postgresql_image: [ "circleci/postgres:10-alpine-ram", "cimg/postgres:12.15", "cimg/postgres:13.11" ]
       - docker-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/ruby-27
 
 USER root
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
-  && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs --skip-broken -y shared-mime-info postgresql13 postgresql13-devel postgresql13-libs \
+  && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs --skip-broken -y shared-mime-info postgresql13 postgresql13-libs \
   && dnf clean all \
   && rm -rf /var/cache/yum
 

--- a/db/structure-10.sql
+++ b/db/structure-10.sql
@@ -37,8 +37,6 @@ $$;
 
 SET default_tablespace = '';
 
-SET default_table_access_method = heap;
-
 --
 -- Name: que_jobs; Type: TABLE; Schema: public; Owner: -
 --
@@ -1293,14 +1291,14 @@ CREATE INDEX table_channel_id_index ON public.message_bus USING btree (channel, 
 -- Name: que_jobs que_job_notify; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER que_job_notify AFTER INSERT ON public.que_jobs FOR EACH ROW EXECUTE FUNCTION public.que_job_notify();
+CREATE TRIGGER que_job_notify AFTER INSERT ON public.que_jobs FOR EACH ROW EXECUTE PROCEDURE public.que_job_notify();
 
 
 --
 -- Name: que_jobs que_state_notify; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER que_state_notify AFTER INSERT OR DELETE OR UPDATE ON public.que_jobs FOR EACH ROW EXECUTE FUNCTION public.que_state_notify();
+CREATE TRIGGER que_state_notify AFTER INSERT OR DELETE OR UPDATE ON public.que_jobs FOR EACH ROW EXECUTE PROCEDURE public.que_state_notify();
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -37,6 +37,8 @@ $$;
 
 SET default_tablespace = '';
 
+SET default_table_access_method = heap;
+
 --
 -- Name: que_jobs; Type: TABLE; Schema: public; Owner: -
 --
@@ -121,7 +123,9 @@ CREATE FUNCTION public.que_job_notify() RETURNS trigger
         FROM (
           SELECT *
           FROM public.que_lockers ql, generate_series(1, ql.worker_count) AS id
-          WHERE listening AND queues @> ARRAY[NEW.queue]
+          WHERE
+            listening AND
+            queues @> ARRAY[NEW.queue]
           ORDER BY md5(pid::text || id::text)
         ) t1
       ) t2
@@ -1291,14 +1295,14 @@ CREATE INDEX table_channel_id_index ON public.message_bus USING btree (channel, 
 -- Name: que_jobs que_job_notify; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER que_job_notify AFTER INSERT ON public.que_jobs FOR EACH ROW EXECUTE PROCEDURE public.que_job_notify();
+CREATE TRIGGER que_job_notify AFTER INSERT ON public.que_jobs FOR EACH ROW EXECUTE FUNCTION public.que_job_notify();
 
 
 --
 -- Name: que_jobs que_state_notify; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER que_state_notify AFTER INSERT OR DELETE OR UPDATE ON public.que_jobs FOR EACH ROW EXECUTE PROCEDURE public.que_state_notify();
+CREATE TRIGGER que_state_notify AFTER INSERT OR DELETE OR UPDATE ON public.que_jobs FOR EACH ROW EXECUTE FUNCTION public.que_state_notify();
 
 
 --
@@ -1511,3 +1515,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190603140450'),
 ('20190605094424'),
 ('20210504152609');
+
+

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -28,7 +28,8 @@ ActiveRecord::Tasks::PostgreSQLDatabaseTasks.prepend(Module.new do
     clear_active_connections!
     establish_master_connection
     server_version = connection.select_value("SHOW server_version").to_i
-    suffix = server_version < 11 ? '' : '-12'
+    raise "PostgreSQL #{server_version} is not supported" if server_version < 10 || server_version == 11
+    suffix = server_version == 10 ? '-10' : ''
     ENV['SCHEMA'] ||= "db/structure#{suffix}.sql"
     clear_active_connections!
   end


### PR DESCRIPTION
Add PostgreSQL 12 to tests, as we're still using it.

This PR also changes the names of the `structure.sql` file.

There have been two versions: `structure.sql` that was used for PostgreSQL version 10 and below, and `structure-12.sql` used for all other versions. This is very confusing as:
1. `structure-12.sql` would be used for PostgreSQL v13
2. `structure-12.sql` would also be used for PostgreSQL v11, BUT it would not work because of one statement unsupported in v11. There was in fact some discussion around it in Slack, but as we lost history, I don't think I'll be able to recover the details.

The differences between the two files are:

1. The following statement:
```
SET default_table_access_method = heap;
```

This appeared in PostgreSQL v12, and is not supported in earlier versions (this is why it would fail with PostgreSQL v11)

2. The following change in CREATE TRIGGER syntax:

```
CREATE TRIGGER xxx FOR EACH ROW EXECUTE FUNCTION yyy
```
is the preferred way to write the triggers, but in v10 only the following is supported:
```
CREATE TRIGGER xxx FOR EACH ROW EXECUTE PROCEDURE yyy
```

see https://www.postgresql.org/docs/release/11.0/
```
Also, writing FUNCTION is now preferred over writing PROCEDURE in CREATE OPERATOR and CREATE TRIGGER, because the referenced object must be a function not a procedure. However, the old syntax is still accepted for compatibility.
```

With this update, we:
- make it explicit that older versions of Postgres, as well as version 11 are not supported
- make it possible to get rid of `structure-10.sql` easily once we fully stop supporting it
