### PR TITLE
Ruby upgrade to v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,7 @@ jobs:
       # Restore bundle cache
       - restore_cache:
           keys:
-            - zync-bundle-v2-{{ arch }}-{{ checksum "Gemfile.lock" }}
-            - zync-bundle-v2-{{ arch }}-{{ .Branch }}
-            - zync-branch-v2-{{ arch }}-master
+            - zync-bundle-v2-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Gemfile.lock" }}
 
       - run:
           name: bundle install
@@ -59,7 +57,7 @@ jobs:
           command: BUNDLE_WITHOUT=development:test bundle exec bin/rails runner --environment=production 'puts Rails.env'
 
       - save_cache:
-          key: zync-bundle-v2-{{ arch }}-{{ checksum "Gemfile.lock" }}
+          key: zync-bundle-v2-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,8 @@ jobs:
         type: string
     working_directory: /opt/app-root/zync
     docker:
-      - image: registry.access.redhat.com/ubi7/ruby-27
+      # A Zync image tagged manually for CI tests
+      - image: quay.io/3scale/zync:ci-builder
       - image: << parameters.postgresql_image >>
     environment:
         RAILS_ENV: test
@@ -48,7 +49,7 @@ jobs:
       - run:
           name: bundle install
           command: |
-            gem install bundler --version=$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tr -d ' '| tail -n 1)
+            gem install bundler --version=$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tr -d ' '| tail -n 1) --no-document
             bundle config --local force_ruby_platform true
             bundle config set --local deployment 'true'
             bundle config set --local path 'vendor/bundle'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - run:
           name: rails test
           command: |
-            circleci tests glob "test/**/*_test.rb" | circleci tests run --command="xargs bundle exec rails test" --verbose --split-by=timings
+            circleci tests glob "test/**/*_test.rb" | circleci tests run --command="xargs bundle exec rake test TESTOPTS='-v'" --verbose --split-by=timings
       - run:
           name: license_finder
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - run:
           name: rails test
           command: |
-            bundle exec bin/rails test $(circleci tests glob "test/**/*_test.rb" | circleci tests split --split-by=timings)
+            circleci tests glob "test/**/*_test.rb" | circleci tests run --command="xargs bundle exec rails test" --verbose --split-by=timings
       - run:
           name: license_finder
           command: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Regarding code style like indentation and whitespace, **follow the conventions y
 You can look at `.rubocop.yml` and `.codeclimate.yml`
 
 ## Modifying the code
-First, ensure that you have installed Ruby 2.3+ and recent PostgreSQL.
+First, ensure that you have installed Ruby 3.1 and recent PostgreSQL.
 
 1. Fork and clone the repo.
 1. Run `bundle install` to install all dependencies.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM registry.access.redhat.com/ubi9/ruby-31
 
 USER root
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
-    && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs --skip-broken -y shared-mime-info postgresql13 postgresql13-libs \
+RUN dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs -y shared-mime-info postgresql rubygem-irb rubygem-rdoc \
     && dnf clean all \
     && rm -rf /var/cache/yum
+
+# worksround https://bugzilla.redhat.com/show_bug.cgi?id=2221938
+RUN ln -s /usr/share/gems/gems/rdoc-6.4.0/lib/rdoc.rb /usr/share/ruby/ \
+    ln -s /usr/share/gems/gems/rdoc-6.4.0/lib/rdoc /usr/share/ruby/
 
 USER default
 WORKDIR ${APP_ROOT}
@@ -14,8 +17,7 @@ COPY --chown=default:root Gemfile* ./
 RUN BUNDLER_VERSION=$(awk '/BUNDLED WITH/ { getline; print $1 }' Gemfile.lock) \
     && gem install bundler --version=$BUNDLER_VERSION --no-document
 
-RUN bundle config build.pg --with-pg-config=/usr/pgsql-13/bin/pg_config \
-    && bundle config set --local deployment 'true' \
+RUN bundle config set --local deployment 'true' \
     && bundle config set --local path 'vendor/bundle' \
     && bundle install --jobs $(grep -c processor /proc/cpuinfo) --retry 3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs -y s
     && dnf clean all \
     && rm -rf /var/cache/yum
 
-# worksround https://bugzilla.redhat.com/show_bug.cgi?id=2221938
+# Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2221938
 RUN ln -s /usr/share/gems/gems/rdoc-6.4.0/lib/rdoc.rb /usr/share/ruby/ \
     ln -s /usr/share/gems/gems/rdoc-6.4.0/lib/rdoc /usr/share/ruby/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.access.redhat.com/ubi8/ruby-27
+FROM registry.access.redhat.com/ubi9/ruby-31
 
 USER root
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
-  && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs --skip-broken -y shared-mime-info postgresql13 postgresql13-libs \
-  && dnf clean all \
-  && rm -rf /var/cache/yum
+    && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs --skip-broken -y shared-mime-info postgresql13 postgresql13-libs \
+    && dnf clean all \
+    && rm -rf /var/cache/yum
 
 USER default
 WORKDIR ${APP_ROOT}
@@ -15,18 +15,20 @@ RUN BUNDLER_VERSION=$(awk '/BUNDLED WITH/ { getline; print $1 }' Gemfile.lock) \
     && gem install bundler --version=$BUNDLER_VERSION --no-document
 
 RUN bundle config build.pg --with-pg-config=/usr/pgsql-13/bin/pg_config \
-  && bundle install --deployment --path vendor/bundle --jobs $(grep -c processor /proc/cpuinfo) --retry 3
+    && bundle config set --local deployment 'true' \
+    && bundle config set --local path 'vendor/bundle' \
+    && bundle install --jobs $(grep -c processor /proc/cpuinfo) --retry 3
 
 COPY --chown=default:root . .
 
 ENV RAILS_LOG_TO_STDOUT=1
 
 RUN bundle exec bin/rails server -e production -d; \
-  rm -rf tmp/pids
+    rm -rf tmp/pids
 
 RUN mkdir -p -m 0775 tmp/cache log \
-  && chown -fR default tmp log db \
-  && chmod -fR g+w tmp log db
+    && chown -fR default tmp log db \
+    && chmod -fR g+w tmp log db
 
 # Bundler runs git commands on git dependencies
 # https://bundler.io/guides/git.html#local-git-repos

--- a/Gemfile
+++ b/Gemfile
@@ -71,9 +71,6 @@ group :development, :test do
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
-
-  gem 'irb'
-  gem 'rdoc'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem 'yabeda-rails'
 gem 'yabeda-prometheus', '~> 0.6.1'
 gem 'yabeda-puma-plugin'
 
+# Dependency for yabeda-prometheus
+gem 'webrick'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -68,6 +71,9 @@ group :development, :test do
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
+
+  gem 'irb'
+  gem 'rdoc'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,9 @@ GEM
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     interception (0.5)
+    io-console (0.5.11)
+    irb (1.4.1)
+      reline (>= 0.3.0)
     json (2.5.1)
     jsonpath (0.9.9)
       multi_json
@@ -234,6 +237,8 @@ GEM
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
+    psych (4.0.4)
+      stringio
     public_suffix (4.0.6)
     puma (5.2.1)
       nio4r (~> 2.0)
@@ -275,8 +280,12 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    rdoc (6.4.0)
+      psych (>= 4.0.0)
     recursive-open-struct (1.1.3)
     regexp_parser (2.8.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
     request_store (1.5.0)
       rack (>= 1.4)
     responders (3.0.1)
@@ -316,6 +325,7 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.3)
       tilt (~> 2.0)
+    stringio (3.0.1)
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.3.2)
@@ -331,6 +341,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.8.1)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -366,6 +377,7 @@ DEPENDENCIES
   bugsnag-capistrano (< 2)
   codecov
   httpclient!
+  irb
   k8s-ruby
   license_finder (~> 7.0.1)
   lograge
@@ -383,6 +395,7 @@ DEPENDENCIES
   que (~> 2.2.1)
   que-web
   rails (~> 7.0.5)
+  rdoc
   responders (~> 3.0.1)
   rubocop
   rubocop-performance
@@ -391,6 +404,7 @@ DEPENDENCIES
   tzinfo-data
   validate_url
   webmock
+  webrick
   yabeda-prometheus (~> 0.6.1)
   yabeda-puma-plugin
   yabeda-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,9 +141,6 @@ GEM
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     interception (0.5)
-    io-console (0.5.11)
-    irb (1.4.1)
-      reline (>= 0.3.0)
     json (2.5.1)
     jsonpath (0.9.9)
       multi_json
@@ -237,8 +234,6 @@ GEM
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
-    psych (4.0.4)
-      stringio
     public_suffix (4.0.6)
     puma (5.2.1)
       nio4r (~> 2.0)
@@ -280,12 +275,8 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    rdoc (6.4.0)
-      psych (>= 4.0.0)
     recursive-open-struct (1.1.3)
     regexp_parser (2.8.0)
-    reline (0.3.1)
-      io-console (~> 0.5)
     request_store (1.5.0)
       rack (>= 1.4)
     responders (3.0.1)
@@ -325,7 +316,6 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.3)
       tilt (~> 2.0)
-    stringio (3.0.1)
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.3.2)
@@ -377,7 +367,6 @@ DEPENDENCIES
   bugsnag-capistrano (< 2)
   codecov
   httpclient!
-  irb
   k8s-ruby
   license_finder (~> 7.0.1)
   lograge
@@ -395,7 +384,6 @@ DEPENDENCIES
   que (~> 2.2.1)
   que-web
   rails (~> 7.0.5)
-  rdoc
   responders (~> 3.0.1)
   rubocop
   rubocop-performance

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,13 +7,13 @@
 git clone git@github.com:3scale/zync.git
 ```
 
-## Install dependencies.
+## Install dependencies
 
 To run Zync you need access to a running [PostgreSQL](https://www.postgresql.org) server. You can install one with your operating system package
 manager, as a container or run it remotely.
 
 The minimum requirement for the machine running Zync is to have
- - Ruby 2.7.x
+ - Ruby 3.1
  - `psql` client tool - needed when running for `db:setup`
  - `libpq-devel` - needed to build `pg` gem during `bundle install`.
 

--- a/app/adapters/three_scale/api/instrumented_http_client.rb
+++ b/app/adapters/three_scale/api/instrumented_http_client.rb
@@ -5,8 +5,8 @@ require 'securerandom'
 # Custom HTTP Client for 3scale API client with added instrumentation.,
 class ThreeScale::API::InstrumentedHttpClient < ThreeScale::API::HttpClient
 
-  def initialize(**)
-    super
+  def initialize(...)
+    super(...)
 
     if (system_provider_port = ENV['SYSTEM_PROVIDER_PORT'].presence)
       proxy = URI(system_provider_port).freeze

--- a/app/services/integration/kubernetes_service.rb
+++ b/app/services/integration/kubernetes_service.rb
@@ -124,7 +124,7 @@ class Integration::KubernetesService < Integration::ServiceBase
   end
 
   class Route < K8s::Resource
-    def initialize(attributes, **options)
+    def initialize(attributes, options = {})
       super attributes.with_indifferent_access
                       .merge(apiVersion: 'route.openshift.io/v1', kind: 'Route')
                       .reverse_merge(metadata: {}), **options

--- a/test/jobs/process_entry_job_test.rb
+++ b/test/jobs/process_entry_job_test.rb
@@ -71,6 +71,7 @@ class ProcessEntryJobTest < ActiveJob::TestCase
   end
 
   test 'race condition between entry jobs to create same proxy integration' do
+    skip "see https://github.com/rails/rails/pull/46553" if Rails.version <= Gem::Version.new('7.0.6')
     entry = entries(:proxy)
 
     existing_integrations = Integration.where(tenant: entry.tenant)

--- a/test/jobs/process_entry_job_test.rb
+++ b/test/jobs/process_entry_job_test.rb
@@ -71,7 +71,7 @@ class ProcessEntryJobTest < ActiveJob::TestCase
   end
 
   test 'race condition between entry jobs to create same proxy integration' do
-    skip "see https://github.com/rails/rails/pull/46553" if Rails.version <= Gem::Version.new('7.0.6')
+    skip 'see https://github.com/rails/rails/pull/46553' if Rails.version <= Gem::Version.new('7.0.6')
     entry = entries(:proxy)
 
     existing_integrations = Integration.where(tenant: entry.tenant)

--- a/test/services/incoming_notification_service_test.rb
+++ b/test/services/incoming_notification_service_test.rb
@@ -35,6 +35,10 @@ class IncomingNotificationServiceTest < ActiveSupport::TestCase
   class LockingTest < ActiveSupport::TestCase
     self.use_transactional_tests = false
 
+    def setup
+      skip "see https://github.com/rails/rails/pull/46553" if Rails.version <= Gem::Version.new('7.0.6')
+    end
+
     teardown do
       ::Que.clear!
       ActiveRecord::Base.connection_pool.disconnect!

--- a/test/services/incoming_notification_service_test.rb
+++ b/test/services/incoming_notification_service_test.rb
@@ -32,46 +32,43 @@ class IncomingNotificationServiceTest < ActiveSupport::TestCase
     assert @service.call(n2)
   end
 
-  class LockingTest < ActiveSupport::TestCase
-    self.use_transactional_tests = false
-
-    def setup
-      skip 'see https://github.com/rails/rails/pull/46553' if Rails.version <= Gem::Version.new('7.0.6')
-    end
-
-    teardown do
-      ::Que.clear!
-      ActiveRecord::Base.connection_pool.disconnect!
-    end
-
-    def test_process_locked_model
-      notification = notifications(:two)
-
-      fiber = Fiber.new do
-        first = Model.connection_pool.checkout
-        first.transaction(requires_new: true) do
-          first.execute('SET SESSION statement_timeout TO 100;')
-
-          second = Model.connection_pool.checkout
-          second.transaction(requires_new: true) do
-            second.execute('SET SESSION statement_timeout TO 100;')
-            model = Model.find(notification.model_id)
-
-            UpdateState.acquire_lock(model) do |state|
-              model.touch
-              Fiber.yield state
-            end
-          end
-        end
-      end
-
-      assert_kind_of UpdateState, fiber.resume
-
-      UpdateJob.stub(:perform_later, nil) do
-        assert IncomingNotificationService.call(notification.dup)
-      end
-    ensure
-      assert_nil fiber.resume
-    end
-  end
+  # TODO: enable the test after upgrading to Rails version that fixes https://github.com/rails/rails/pull/46553
+  # class LockingTest < ActiveSupport::TestCase
+  #   self.use_transactional_tests = false
+  #
+  #   teardown do
+  #     ::Que.clear!
+  #     ActiveRecord::Base.connection_pool.disconnect!
+  #   end
+  #
+  #   def test_process_locked_model
+  #     notification = notifications(:two)
+  #
+  #     fiber = Fiber.new do
+  #       first = Model.connection_pool.checkout
+  #       first.transaction(requires_new: true) do
+  #         first.execute('SET SESSION statement_timeout TO 100;')
+  #
+  #         second = Model.connection_pool.checkout
+  #         second.transaction(requires_new: true) do
+  #           second.execute('SET SESSION statement_timeout TO 100;')
+  #           model = Model.find(notification.model_id)
+  #
+  #           UpdateState.acquire_lock(model) do |state|
+  #             model.touch
+  #             Fiber.yield state
+  #           end
+  #         end
+  #       end
+  #     end
+  #
+  #     assert_kind_of UpdateState, fiber.resume
+  #
+  #     UpdateJob.stub(:perform_later, nil) do
+  #       assert IncomingNotificationService.call(notification.dup)
+  #     end
+  #   ensure
+  #     assert_nil fiber&.resume
+  #   end
+  # end
 end

--- a/test/services/incoming_notification_service_test.rb
+++ b/test/services/incoming_notification_service_test.rb
@@ -36,7 +36,7 @@ class IncomingNotificationServiceTest < ActiveSupport::TestCase
     self.use_transactional_tests = false
 
     def setup
-      skip "see https://github.com/rails/rails/pull/46553" if Rails.version <= Gem::Version.new('7.0.6')
+      skip 'see https://github.com/rails/rails/pull/46553' if Rails.version <= Gem::Version.new('7.0.6')
     end
 
     teardown do


### PR DESCRIPTION
Some issues encountered in the upgrade:

1. The dependency `k8s-ruby`, or rather its dependency `recursive-open-struct` uses deprecated arguments passing here: https://github.com/aetherknight/recursive-open-struct/blob/main/lib/recursive_open_struct.rb#L188

It seems that it kind of supports Ruby 3 https://github.com/aetherknight/recursive-open-struct/blob/main/.travis.yml#L15

As well as `k8s-ruby` claims that it supports Ruby 3.1 https://github.com/k8s-ruby/k8s-ruby/commit/30d4db1b8ad991660098c89e55b35ee18aa216c9

But probably it's an edge case...

With Ruby 2.7 there is a deprecation warning: 
```

/home/dmayorov/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/recursive-open-struct-1.1.3/lib/recursive_open_struct.rb:188: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

And with Ruby 3 it fails with ArgumentError.

For now the solution has been changing the arguments of `Integration::KubernetesService::Route.initialize`. But we can review if that's a reasonable fix.

Maybe we can also look into using another library instead of `k8s-ruby`, for example, [Kubernetes documentation](https://kubernetes.io/docs/reference/using-api/client-libraries/#officially-supported-kubernetes-client-libraries) suggests https://kubernetes.io/docs/reference/using-api/client-libraries/ as officially supported (also, not sure if it's well-maintained).

2. Test suite was getting either stuck (in CircleCI), or failing with the following error:
```
ThreadError: deadlock; lock already owned by another fiber belonging to the same thread
```
After looking into it, it turned out to be caused by two tests that explicitly used Fibers.

Apparently, this does not work well within a transaction. There is a fix applied here: https://github.com/rails/rails/pull/46553 (that we confirmed would fix the tests for us).

However, it's not in the latest released version of Rails (not in 7.0.6 at least). So, we're skipping these tests for now, until we upgrade Rails to a version where this is fixed.

3. There were some issues with the `ubi9/ruby-31` base image, for example, `rdoc` is not present as a default Gem. @akostadinov railsed an issue in Bugzilla for this: https://bugzilla.redhat.com/show_bug.cgi?id=2221938

Also, both `irb` and `rdoc` were not available by default and had to be installed explicitly.