### PR TITLE
:broom: Remove bugsnag-capistrano dependency and update licenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,6 @@ gem 'puma', '~> 5.2'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
-
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
@@ -35,9 +32,6 @@ gem 'que', '~> 2.2.1'
 gem 'que-web'
 
 gem 'bugsnag'
-# bugsnag-capistrano 2.x does not have a rake task to report deploys
-# https://github.com/bugsnag/bugsnag-capistrano/blob/8bcfb27cf6eaff312eef086cce729d553a431460/UPGRADING.md
-gem 'bugsnag-capistrano', '< 2', require: false
 
 # This fork allows setting SSL_CERT_FILE and SSL_CERT_DIR
 # https://github.com/nahi/httpclient/issues/369

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,6 @@ GEM
       msgpack (~> 1.2)
     bugsnag (6.19.0)
       concurrent-ruby (~> 1.0)
-    bugsnag-capistrano (1.1.2)
     builder (3.2.4)
     byebug (11.1.3)
     codecov (0.4.3)
@@ -366,7 +365,6 @@ DEPENDENCIES
   activerecord-pg_enum
   bootsnap (>= 1.4.4)
   bugsnag
-  bugsnag-capistrano (< 2)
   codecov
   httpclient!
   k8s-ruby

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require 'bugsnag-capistrano/tasks'
 require_relative 'config/application'
 
 Rails.application.load_tasks

--- a/doc/licenses/licenses.xml
+++ b/doc/licenses/licenses.xml
@@ -13,7 +13,7 @@
       </dependency>
           <dependency>
         <packageName>actioncable</packageName>
-        <version>6.1.7.1</version>
+        <version>7.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -23,7 +23,7 @@
       </dependency>
           <dependency>
         <packageName>actionmailbox</packageName>
-        <version>6.1.7.1</version>
+        <version>7.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -33,7 +33,7 @@
       </dependency>
           <dependency>
         <packageName>actionmailer</packageName>
-        <version>6.1.7.1</version>
+        <version>7.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -43,7 +43,7 @@
       </dependency>
           <dependency>
         <packageName>actionpack</packageName>
-        <version>6.1.7.1</version>
+        <version>7.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -53,7 +53,7 @@
       </dependency>
           <dependency>
         <packageName>actiontext</packageName>
-        <version>6.1.7.1</version>
+        <version>7.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -63,7 +63,7 @@
       </dependency>
           <dependency>
         <packageName>actionview</packageName>
-        <version>6.1.7.1</version>
+        <version>7.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -73,7 +73,7 @@
       </dependency>
           <dependency>
         <packageName>activejob</packageName>
-        <version>6.1.7.1</version>
+        <version>7.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -83,7 +83,7 @@
       </dependency>
           <dependency>
         <packageName>activemodel</packageName>
-        <version>6.1.7.1</version>
+        <version>7.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -93,7 +93,7 @@
       </dependency>
           <dependency>
         <packageName>activerecord</packageName>
-        <version>6.1.7.1</version>
+        <version>7.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -103,7 +103,7 @@
       </dependency>
           <dependency>
         <packageName>activerecord-pg_enum</packageName>
-        <version>1.2.2</version>
+        <version>2.0.0</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -113,7 +113,7 @@
       </dependency>
           <dependency>
         <packageName>activestorage</packageName>
-        <version>6.1.7.1</version>
+        <version>7.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -123,7 +123,7 @@
       </dependency>
           <dependency>
         <packageName>activesupport</packageName>
-        <version>6.1.7.1</version>
+        <version>7.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -133,7 +133,7 @@
       </dependency>
           <dependency>
         <packageName>bootsnap</packageName>
-        <version>1.7.2</version>
+        <version>1.16.0</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -144,16 +144,6 @@
           <dependency>
         <packageName>bugsnag</packageName>
         <version>6.19.0</version>
-        <licenses>
-                      <license>
-              <name>MIT</name>
-              <url>http://opensource.org/licenses/mit-license</url>
-            </license>
-                  </licenses>
-      </dependency>
-          <dependency>
-        <packageName>bugsnag-capistrano</packageName>
-        <version>1.1.2</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -173,7 +163,7 @@
       </dependency>
           <dependency>
         <packageName>bundler</packageName>
-        <version>2.3.25</version>
+        <version>2.4.17</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -183,7 +173,7 @@
       </dependency>
           <dependency>
         <packageName>concurrent-ruby</packageName>
-        <version>1.1.10</version>
+        <version>1.2.2</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -217,7 +207,7 @@
       </dependency>
           <dependency>
         <packageName>dry-configurable</packageName>
-        <version>0.9.0</version>
+        <version>0.13.0</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -227,7 +217,7 @@
       </dependency>
           <dependency>
         <packageName>dry-container</packageName>
-        <version>0.7.2</version>
+        <version>0.11.0</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -237,17 +227,7 @@
       </dependency>
           <dependency>
         <packageName>dry-core</packageName>
-        <version>0.4.9</version>
-        <licenses>
-                      <license>
-              <name>MIT</name>
-              <url>http://opensource.org/licenses/mit-license</url>
-            </license>
-                  </licenses>
-      </dependency>
-          <dependency>
-        <packageName>dry-equalizer</packageName>
-        <version>0.3.0</version>
+        <version>0.9.1</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -257,7 +237,7 @@
       </dependency>
           <dependency>
         <packageName>dry-inflector</packageName>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -277,7 +257,7 @@
       </dependency>
           <dependency>
         <packageName>dry-logic</packageName>
-        <version>0.6.1</version>
+        <version>1.3.0</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -287,7 +267,7 @@
       </dependency>
           <dependency>
         <packageName>dry-struct</packageName>
-        <version>0.5.1</version>
+        <version>1.5.2</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -297,7 +277,7 @@
       </dependency>
           <dependency>
         <packageName>dry-types</packageName>
-        <version>0.13.4</version>
+        <version>1.6.1</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -317,7 +297,7 @@
       </dependency>
           <dependency>
         <packageName>excon</packageName>
-        <version>0.71.1</version>
+        <version>0.100.0</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -347,7 +327,7 @@
       </dependency>
           <dependency>
         <packageName>globalid</packageName>
-        <version>1.0.1</version>
+        <version>1.1.0</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -377,7 +357,7 @@
       </dependency>
           <dependency>
         <packageName>i18n</packageName>
-        <version>1.12.0</version>
+        <version>1.14.1</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -426,8 +406,8 @@
                   </licenses>
       </dependency>
           <dependency>
-        <packageName>k8s-client</packageName>
-        <version>0.10.4</version>
+        <packageName>k8s-ruby</packageName>
+        <version>0.14.0</version>
         <licenses>
                       <license>
               <name>Apache 2.0</name>
@@ -437,7 +417,7 @@
       </dependency>
           <dependency>
         <packageName>lograge</packageName>
-        <version>0.11.2</version>
+        <version>0.12.0</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -447,7 +427,7 @@
       </dependency>
           <dependency>
         <packageName>loofah</packageName>
-        <version>2.19.1</version>
+        <version>2.21.3</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -457,7 +437,7 @@
       </dependency>
           <dependency>
         <packageName>mail</packageName>
-        <version>2.8.0.1</version>
+        <version>2.8.1</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -511,7 +491,7 @@
       </dependency>
           <dependency>
         <packageName>minitest</packageName>
-        <version>5.17.0</version>
+        <version>5.18.1</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -521,7 +501,7 @@
       </dependency>
           <dependency>
         <packageName>msgpack</packageName>
-        <version>1.4.2</version>
+        <version>1.7.1</version>
         <licenses>
                       <license>
               <name>Apache 2.0</name>
@@ -561,7 +541,7 @@
       </dependency>
           <dependency>
         <packageName>mustermann</packageName>
-        <version>1.1.1</version>
+        <version>2.0.2</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -571,7 +551,7 @@
       </dependency>
           <dependency>
         <packageName>net-imap</packageName>
-        <version>0.3.4</version>
+        <version>0.3.6</version>
         <licenses>
                       <license>
               <name>Simplified BSD</name>
@@ -627,7 +607,7 @@
       </dependency>
           <dependency>
         <packageName>nio4r</packageName>
-        <version>2.5.8</version>
+        <version>2.5.9</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -637,7 +617,7 @@
       </dependency>
           <dependency>
         <packageName>nokogiri</packageName>
-        <version>1.14.0</version>
+        <version>1.15.3</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -697,7 +677,7 @@
       </dependency>
           <dependency>
         <packageName>que</packageName>
-        <version>1.0.0.beta4</version>
+        <version>2.2.1</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -707,7 +687,7 @@
       </dependency>
           <dependency>
         <packageName>que-web</packageName>
-        <version>0.9.3</version>
+        <version>0.10.0</version>
         <licenses>
                       <license>
               <name>BSD</name>
@@ -717,7 +697,7 @@
       </dependency>
           <dependency>
         <packageName>racc</packageName>
-        <version>1.6.2</version>
+        <version>1.7.1</version>
         <licenses>
                       <license>
               <name>Simplified BSD</name>
@@ -731,7 +711,7 @@
       </dependency>
           <dependency>
         <packageName>rack</packageName>
-        <version>2.2.6.2</version>
+        <version>2.2.7</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -741,7 +721,7 @@
       </dependency>
           <dependency>
         <packageName>rack-protection</packageName>
-        <version>2.2.0</version>
+        <version>2.2.3</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -751,7 +731,7 @@
       </dependency>
           <dependency>
         <packageName>rack-test</packageName>
-        <version>2.0.2</version>
+        <version>2.1.0</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -761,7 +741,7 @@
       </dependency>
           <dependency>
         <packageName>rails</packageName>
-        <version>6.1.7.1</version>
+        <version>7.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -771,7 +751,7 @@
       </dependency>
           <dependency>
         <packageName>rails-dom-testing</packageName>
-        <version>2.0.3</version>
+        <version>2.1.1</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -781,7 +761,7 @@
       </dependency>
           <dependency>
         <packageName>rails-html-sanitizer</packageName>
-        <version>1.4.4</version>
+        <version>1.6.0</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -791,7 +771,7 @@
       </dependency>
           <dependency>
         <packageName>railties</packageName>
-        <version>6.1.7.1</version>
+        <version>7.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -811,7 +791,7 @@
       </dependency>
           <dependency>
         <packageName>recursive-open-struct</packageName>
-        <version>1.1.0</version>
+        <version>1.1.3</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -855,27 +835,7 @@
       </dependency>
           <dependency>
         <packageName>sinatra</packageName>
-        <version>2.2.0</version>
-        <licenses>
-                      <license>
-              <name>MIT</name>
-              <url>http://opensource.org/licenses/mit-license</url>
-            </license>
-                  </licenses>
-      </dependency>
-          <dependency>
-        <packageName>sprockets</packageName>
-        <version>4.2.0</version>
-        <licenses>
-                      <license>
-              <name>MIT</name>
-              <url>http://opensource.org/licenses/mit-license</url>
-            </license>
-                  </licenses>
-      </dependency>
-          <dependency>
-        <packageName>sprockets-rails</packageName>
-        <version>3.4.2</version>
+        <version>2.2.3</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -885,7 +845,7 @@
       </dependency>
           <dependency>
         <packageName>thor</packageName>
-        <version>1.2.1</version>
+        <version>1.2.2</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -895,7 +855,7 @@
       </dependency>
           <dependency>
         <packageName>tilt</packageName>
-        <version>2.0.10</version>
+        <version>2.0.11</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -905,7 +865,7 @@
       </dependency>
           <dependency>
         <packageName>timeout</packageName>
-        <version>0.3.1</version>
+        <version>0.4.0</version>
         <licenses>
                       <license>
               <name>Simplified BSD</name>
@@ -929,7 +889,7 @@
       </dependency>
           <dependency>
         <packageName>tzinfo</packageName>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -939,11 +899,25 @@
       </dependency>
           <dependency>
         <packageName>validate_url</packageName>
-        <version>1.0.13</version>
+        <version>1.0.15</version>
         <licenses>
                       <license>
               <name>MIT</name>
               <url>http://opensource.org/licenses/mit-license</url>
+            </license>
+                  </licenses>
+      </dependency>
+          <dependency>
+        <packageName>webrick</packageName>
+        <version>1.8.1</version>
+        <licenses>
+                      <license>
+              <name>Simplified BSD</name>
+              <url>http://opensource.org/licenses/bsd-license</url>
+            </license>
+                      <license>
+              <name>ruby</name>
+              <url>http://www.ruby-lang.org/en/LICENSE.txt</url>
             </license>
                   </licenses>
       </dependency>
@@ -1009,7 +983,7 @@
       </dependency>
           <dependency>
         <packageName>yajl-ruby</packageName>
-        <version>1.4.1</version>
+        <version>1.4.3</version>
         <licenses>
                       <license>
               <name>MIT</name>
@@ -1018,8 +992,8 @@
                   </licenses>
       </dependency>
           <dependency>
-        <packageName>yaml-safe_load_stream</packageName>
-        <version>0.1.1</version>
+        <packageName>yaml-safe_load_stream3</packageName>
+        <version>0.1.2</version>
         <licenses>
                       <license>
               <name>Apache 2.0</name>
@@ -1029,7 +1003,7 @@
       </dependency>
           <dependency>
         <packageName>zeitwerk</packageName>
-        <version>2.6.6</version>
+        <version>2.6.8</version>
         <licenses>
                       <license>
               <name>MIT</name>


### PR DESCRIPTION
We are not using capistrano for deployments, so just cleaning up unneeded deps.

Also, when updating the licenses file I realized that it was not updated after Rails upgrade.

Probably we need to generate it in the container build, like we do for Porta... 