### PR TITLE
Upgrade JSON default gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     interception (0.5)
-    json (2.5.1)
+    json (2.6.1)
     jsonpath (0.9.9)
       multi_json
       to_regexp (~> 0.2.1)


### PR DESCRIPTION
The default version of `json` gem for Ruby 3.1 is `2.6.1`, see: https://stdgems.org/3.1.0/

So, set it in the `Gemfile.lock` to avoid the error:

```
You have already activated json 2.6.1, but your Gemfile requires json 2.5.1. Since json is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports json as a default gem. (Gem::LoadError)
```