### PR TITLE
Upgrade Nokogiri to v1.16.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
       rack (>= 1.1.3)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
+    mini_portile2 (2.8.6)
     minitest (5.18.1)
     minitest-reporters (1.4.3)
       ansi
@@ -204,7 +204,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.3)
+    nokogiri (1.16.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth2 (1.4.7)
@@ -240,7 +240,7 @@ GEM
     que-web (0.10.0)
       que (>= 1)
       sinatra
-    racc (1.7.1)
+    racc (1.7.3)
     rack (2.2.7)
     rack-protection (2.2.3)
       rack


### PR DESCRIPTION
Supersedes https://github.com/3scale/zync/pull/523 and https://github.com/3scale/zync/pull/519