### PR TITLE
THREESCALE-11063: Fix parsing response if Content-Type contains charset

### DIFF
--- a/app/adapters/abstract_adapter.rb
+++ b/app/adapters/abstract_adapter.rb
@@ -94,9 +94,10 @@ class AbstractAdapter
 
     content_type = response.content_type.presence or return body
 
-    case Mime::Type.lookup(content_type)
-    when JSON_TYPE then JSON.parse(body)
-    else raise InvalidResponseError.new response: response, message: 'Unknown Content-Type'
+    if Mime::Type.lookup(content_type).match? JSON_TYPE
+      JSON.parse(body)
+    else
+      raise InvalidResponseError.new response: response, message: 'Unknown Content-Type'
     end
   end
 

--- a/test/adapters/abstract_adapter_test.rb
+++ b/test/adapters/abstract_adapter_test.rb
@@ -38,4 +38,15 @@ class AbstractAdapterTest < ActiveSupport::TestCase
       assert_nil subject.new('https://example.com').authentication
     end
   end
+
+  test 'content-type with charset' do
+    content_type = 'application/json;charset=UTF-8'
+    stub_request(:get, 'https://example.com/.well-known/openid-configuration').
+      to_return(body: '{}', headers: {'Content-Type': content_type})
+    stub_request(:post, 'https://example.com').to_return(status: 200, body: '{"access_token": "test"}', headers: {'Content-Type': content_type})
+    
+    assert_nothing_raised do
+      subject.new('https://example.com').authentication
+    end
+  end
 end


### PR DESCRIPTION
Fixing the issue: https://issues.redhat.com/browse/THREESCALE-11063

It was failing previously with:
```
AbstractAdapter::OIDC::AuthenticationError: Unknown Content-Type
```
