### PR TITLE
THREESCALE-8920: Support for PostgreSQL 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - setup_remote_docker
       - run: docker build --tag zync:build --file ./Dockerfile .
       - run: docker network create net0
-      - run: docker run --net net0 --name ${POSTGRES_CONTAINER_NAME} -d -p 5432:5432 -e POSTGRES_USER=${POSTGRES_USER} -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -e POSTGRES_DB=${POSTGRES_DB} postgres:13-alpine
+      - run: docker run --net net0 --name ${POSTGRES_CONTAINER_NAME} -d -p 5432:5432 -e POSTGRES_USER=${POSTGRES_USER} -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -e POSTGRES_DB=${POSTGRES_DB} postgres:14-alpine
       - run:
           command: |
             docker run --net net0 -e RAILS_ENV=${RAILS_ENV} -e DATABASE_URL=${DATABASE_URL} \
@@ -89,5 +89,5 @@ workflows:
       - build:
           matrix:
             parameters:
-              postgresql_image: [ "circleci/postgres:10-alpine-ram", "cimg/postgres:12.15", "cimg/postgres:13.11" ]
+              postgresql_image: [ "circleci/postgres:10-alpine-ram", "cimg/postgres:12.15", "cimg/postgres:13.11", "cimg/postgres:14.12" ]
       - docker-build


### PR DESCRIPTION
**What this PR does / why we need it**:

Postgres 13 will be EOL soon, we need to officially support Postgres14.

After a research, I would say we already support it completely, so this PR only updates the CircleCI pipeline. More info below.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-8920

**Special notes for your reviewer**:

This is the list of checks and tests I made:

- Check our `pg` gem version supports Postgres 14
  - We use `1.2.3`
  - The first mention to Postgres 14 in the Changelog is in the version [`1.3.0`](https://github.com/ged/ruby-pg/blob/master/History.md#v130-2022-01-20-michael-granger-gedfaeriemudorg), however, everything seems to work fine for us using `1.2.3`.
- Reset database with `bundle exec rails db:reset`
  - Working fine locally
- Create triggers
  - AFAIK they are created when running `bundle exec rails db:reset`
  - I checked they are created in the DB, so they work fine locally
- Add a job for Postgres14 on CircleCI and launch tests
  - All pass
- Check Dockerfiles in upstream and midstream
  - I don't think there's a reason they should be wrong, there's no mention to any particular postgres version in the dockerfiles
- Go through release notes to try to spot any breaking change
  - https://www.postgresql.org/docs/14/release-14.html#id-1.11.6.17.4
  - All changes are low level and should be managed by `rails` and `pg`.
  - The only place where we invoke PostgreSQL code is in trigger creation (AFAIK), and those are created correctly.

Any more ideas?