### PR TITLE
THREESCALE-4185: Support TLS protected PostgreSQL

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -11,6 +11,10 @@ default: &default
   connect_timeout: 5
   variables:
     statement_timeout: 5000 # ms
+  sslmode: <%= ENV.fetch('DATABASE_SSL_CA', nil) ? 'verify-full' : 'disable' %>
+  sslrootcert: <%= ENV['DATABASE_SSL_CA'] %>
+  sslcert: <%= ENV['DATABASE_SSL_CERT'] %>
+  sslkey: <%= ENV['DATABASE_SSL_KEY'] %>
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,7 +11,7 @@ default: &default
   connect_timeout: 5
   variables:
     statement_timeout: 5000 # ms
-  sslmode: <%= ENV.fetch('DATABASE_SSL_CA', nil) ? 'verify-full' : 'disable' %>
+  sslmode: <%= ENV.fetch('DATABASE_SSL_MODE', ENV.fetch('DATABASE_SSL_CA', nil) ? 'verify-full' : 'disable') %>
   sslrootcert: <%= ENV['DATABASE_SSL_CA'] %>
   sslcert: <%= ENV['DATABASE_SSL_CERT'] %>
   sslkey: <%= ENV['DATABASE_SSL_KEY'] %>


### PR DESCRIPTION
Our current `pg` gem already supports TLS protected connections to Postgres, however we need to add a few env. vars for the user to provide the certificates and keys.

https://issues.redhat.com/browse/THREESCALE-4185

These variables will be set by the operator. Check the ticket: https://issues.redhat.com/browse/THREESCALE-11156