### PR TITLE
THREESCALE-8271: Add service_id param when fetching client by client ID

### DIFF
--- a/app/services/fetch_service.rb
+++ b/app/services/fetch_service.rb
@@ -62,7 +62,8 @@ class FetchService
 
   def fetch_client(model)
     fetch_entry(model) do |client|
-      client.find_application(application_id: model.record.client_id)
+      record = model.record
+      client.find_application(application_id: record.client_id, service_id: record.service_id)
     end
   end
 

--- a/test/fixtures/integrations.yml
+++ b/test/fixtures/integrations.yml
@@ -12,6 +12,13 @@ keycloak:
   configuration:
     endpoint: 'http://id:pass@example.com'
 
+second_keycloak:
+  tenant: two
+  model: second_service
+  type: Integration::Keycloak
+  configuration:
+    endpoint: 'http://id:pass@second.example.com'
+
 generic:
   tenant: one
   model: first_service

--- a/test/fixtures/models.yml
+++ b/test/fixtures/models.yml
@@ -12,6 +12,10 @@ first_service:
   tenant: one
   record: one (Service)
 
+second_service:
+  tenant: two
+  record: second (Service)
+
 service:
   tenant: two
   record: two (Service)

--- a/test/fixtures/services.yml
+++ b/test/fixtures/services.yml
@@ -5,3 +5,6 @@ one:
 
 two:
   tenant: two
+
+second:
+  tenant: two

--- a/test/integration/data_model_test.rb
+++ b/test/integration/data_model_test.rb
@@ -84,7 +84,7 @@ class DataModelTest < ActionDispatch::IntegrationTest
         with(headers: http_fetch_headers).
         to_return(body: client.to_json)
 
-    stub_request(:get, "http://example.com/admin/api/applications/find.json?app_id=foo").
+    stub_request(:get, "http://example.com/admin/api/applications/find.json?app_id=foo&service_id=1").
         with(basic_auth: ['', tenant[:access_token]], headers: http_fetch_headers).
         to_return(body: client.to_json).then.
         to_return(body: client.merge(name: 'new-name').to_json).then.
@@ -136,10 +136,9 @@ class DataModelTest < ActionDispatch::IntegrationTest
     perform_enqueued_jobs do
       stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?application_id=1").
           with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
-          to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar' }.to_json).
-          then.to_return(status: 404)
+          to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar' }.to_json)
 
-      stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?app_id=foo").
+      stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?app_id=foo&service_id=298486374").
           with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
           to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar' }.to_json)
 
@@ -175,7 +174,7 @@ class DataModelTest < ActionDispatch::IntegrationTest
         with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
         to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar' }.to_json)
 
-      stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?app_id=foo").
+      stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?app_id=foo&service_id=298486374").
         with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
         to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar' }.to_json)
 
@@ -194,7 +193,7 @@ class DataModelTest < ActionDispatch::IntegrationTest
         with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
         to_return(status: 404)
 
-      stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?app_id=foo").
+      stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?app_id=foo&service_id=298486374").
         with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
         to_return(status: 404)
 

--- a/test/services/fetch_service_test.rb
+++ b/test/services/fetch_service_test.rb
@@ -25,7 +25,7 @@ class FetchServiceTest < ActiveSupport::TestCase
   end
 
   test 'call with Client' do
-    stub_request(:get, "#{tenants(:two).endpoint}/admin/api/applications/find.json?app_id=two").
+    stub_request(:get, "#{tenants(:two).endpoint}/admin/api/applications/find.json?app_id=two&service_id=298486374").
       to_return(status: 200, body: '{}', headers: {})
 
     assert_kind_of Entry, @service.call(models(:client))


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/THREESCALE-8271

It adds `service_id` parameter when fetching application from porta.