### PR TITLE
Switch to a newer postgres 10 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,5 +89,5 @@ workflows:
       - build:
           matrix:
             parameters:
-              postgresql_image: [ "circleci/postgres:10-alpine-ram", "cimg/postgres:12.15", "cimg/postgres:13.11", "cimg/postgres:14.12" ]
+              postgresql_image: [ "cimg/postgres:10.22", "cimg/postgres:12.15", "cimg/postgres:13.11", "cimg/postgres:14.12" ]
       - docker-build


### PR DESCRIPTION
Use a `cimg` image for postgres 10, because `circleci` is deprecated.