### PR TITLE
Change bundler version to 2.3.27 to match the system bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,4 +399,4 @@ DEPENDENCIES
   zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.4.17
+   2.3.27


### PR DESCRIPTION
This is the one we use in the base for the current productized images `registry.redhat.io/ubi9/ruby-31:1`