### PR TITLE
Using plain ubi9 base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           command: |
             docker run --net net0 -e RAILS_ENV=${RAILS_ENV} -e DATABASE_URL=${DATABASE_URL} \
-            zync:build rails db:setup
+            zync:build bundle exec rails db:setup
 
   build:
     parameters:


### PR DESCRIPTION
`registry.access.redhat.com/ubi9/ruby-31` is deprecated...