### PR TITLE
THREESCALE-12448 - Add configuration option to enable openshift deterministically

### DIFF
--- a/app/adapters/three_scale/api/instrumented_http_client.rb
+++ b/app/adapters/three_scale/api/instrumented_http_client.rb
@@ -8,8 +8,14 @@ class ThreeScale::API::InstrumentedHttpClient < ThreeScale::API::HttpClient
   def initialize(...)
     super(...)
 
-    if (system_provider_port = ENV['SYSTEM_PROVIDER_PORT'].presence)
-      proxy = URI(system_provider_port).freeze
+    # When set, API calls to porta are proxied through the internal cluster
+    # service (plain HTTP) instead of the tenant's external endpoint (HTTPS).
+    # X-Forwarded-Host carries the tenant's admin domain for virtual host routing.
+    #
+    # SYSTEM_PROVIDER_URL - explicit URL set by the operator (e.g. http://system-provider:3000)
+    # SYSTEM_PROVIDER_PORT - legacy: injected by Kubernetes service discovery
+    if (system_provider_url = (ENV['SYSTEM_PROVIDER_URL'] || ENV['SYSTEM_PROVIDER_PORT']).presence)
+      proxy = URI(system_provider_url).freeze
 
       @http = Net::HTTP.new(proxy.host, proxy.port)
       @http.set_debug_output($stdout) if debug?

--- a/config/openshift.yml
+++ b/config/openshift.yml
@@ -1,16 +1,8 @@
 default: &default
-  enabled: <%=
-    ENV.values_at(
-      'APICAST_STAGING_SERVICE_PORT_GATEWAY',
-      'APICAST_STAGING_SERVICE_PORT_GATEWAY',
-      'SYSTEM_DEVELOPER_SERVICE_PORT_HTTP',
-      'SYSTEM_PROVIDER_SERVICE_PORT_HTTP',
-      'SYSTEM_MASTER_SERVICE_PORT_HTTP',
-    ).all?
-  %>
+  enabled: true
 
 development:
-  <<: *default
+  enabled: false
 production:
   <<: *default
 


### PR DESCRIPTION
This is needed by [THREESCALE-12448](https://redhat.atlassian.net/browse/THREESCALE-12448) to enable the openshift integration mode even if the services don't exist yet. 

### Verification

Tested locally to verify that route can be created even if service does not exist. This was done by commenting the apicast routes and developer services - there are 2 services necessary to exist for the startup - the sidekiq requires system-master to be up and zync requires system-provider to be up (it communicates with it - see https://github.com/3scale/zync/blob/a852c448b160082b70ada809a1deec65de4ba073/app/adapters/three_scale/api/instrumented_http_client.rb#L11).

Routes have been created successfully even for apicast and developer portal:

```
% oc get routes
NAME                         HOST/PORT                                                                  PATH   SERVICES             PORT      TERMINATION     WILDCARD
backend                      backend-3scale.apps.3scale-bu.3scale.app-services-dev.net                         backend-listener     http      edge/Allow      None
zync-3scale-api-crtfb        api-3scale-apicast-production.apps.3scale-bu.3scale.app-services-dev.net          apicast-production   gateway   edge/Redirect   None
zync-3scale-api-msspt        api-3scale-apicast-staging.apps.3scale-bu.3scale.app-services-dev.net             apicast-staging      gateway   edge/Redirect   None
zync-3scale-master-xgf8h     master.apps.3scale-bu.3scale.app-services-dev.net                                 system-master        http      edge/Redirect   None
zync-3scale-provider-nfl98   3scale.apps.3scale-bu.3scale.app-services-dev.net                                 system-developer     http      edge/Redirect   None
zync-3scale-provider-ngtmd   3scale-admin.apps.3scale-bu.3scale.app-services-dev.net                           system-provider      http      edge/Redirect   None
```

```
borisurbanik@Boriss-MacBook-Pro 3scale-operator % oc get deployment zync-que -n 3scale-test -o jsonpath='{.spec.template.spec.containers[0].image}'
quay.io/3scale/zync:true-openshift%
borisurbanik@Boriss-MacBook-Pro 3scale-operator % oc exec deployment/zync-que -- bundle exec rails runner "puts Rails.application.config.x.openshift.enabled"
W, [2026-03-18T15:49:19.100518 #156]  WARN -- [Bugsnag]: No valid API key has been set, notifications will not be sent
true

borisurbanik@Boriss-MacBook-Pro 3scale-operator % oc get svc
NAME               TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
backend-listener   ClusterIP   172.30.238.121   <none>        3000/TCP    9m54s
backend-redis      ClusterIP   172.30.9.96      <none>        6379/TCP    32m
system-master      ClusterIP   172.30.223.6     <none>        3000/TCP    6m31s
system-memcache    ClusterIP   172.30.115.154   <none>        11211/TCP   9m9s
system-mysql       ClusterIP   172.30.240.116   <none>        3306/TCP    32m
system-provider    ClusterIP   172.30.174.35    <none>        3000/TCP    9m9s
system-redis       ClusterIP   172.30.39.81     <none>        6379/TCP    32m
system-searchd     ClusterIP   172.30.210.149   <none>        9306/TCP    9m49s
zync               ClusterIP   172.30.110.145   <none>        8080/TCP    9m10s
zync-database      ClusterIP   172.30.110.194   <none>        5432/TCP    9m10s

borisurbanik@Boriss-MacBook-Pro 3scale-operator % oc exec deployment/zync-que -c que -- env | grep -E 'APICAST_|SYSTEM_'
SYSTEM_REDIS_PORT_6379_TCP_ADDR=172.30.39.81
SYSTEM_SEARCHD_SERVICE_PORT=9306
SYSTEM_PROVIDER_SERVICE_PORT=3000
SYSTEM_MYSQL_SERVICE_HOST=172.30.240.116
SYSTEM_MEMCACHE_PORT_11211_TCP_PROTO=tcp
SYSTEM_REDIS_SERVICE_HOST=172.30.39.81
SYSTEM_MEMCACHE_PORT_11211_TCP=tcp://172.30.115.154:11211
SYSTEM_MYSQL_PORT_3306_TCP_PORT=3306
SYSTEM_MYSQL_PORT_3306_TCP_ADDR=172.30.240.116
SYSTEM_PROVIDER_SERVICE_HOST=172.30.174.35
SYSTEM_PROVIDER_PORT_3000_TCP_PORT=3000
SYSTEM_REDIS_PORT_6379_TCP=tcp://172.30.39.81:6379
SYSTEM_MYSQL_PORT=tcp://172.30.240.116:3306
SYSTEM_PROVIDER_SERVICE_PORT_HTTP=3000
SYSTEM_REDIS_PORT=tcp://172.30.39.81:6379
SYSTEM_REDIS_SERVICE_PORT=6379
SYSTEM_MEMCACHE_SERVICE_PORT_MEMCACHE=11211
SYSTEM_SEARCHD_SERVICE_HOST=172.30.210.149
SYSTEM_SEARCHD_PORT_9306_TCP=tcp://172.30.210.149:9306
SYSTEM_SEARCHD_PORT_9306_TCP_ADDR=172.30.210.149
SYSTEM_PROVIDER_PORT_3000_TCP=tcp://172.30.174.35:3000
SYSTEM_MYSQL_PORT_3306_TCP=tcp://172.30.240.116:3306
SYSTEM_MYSQL_PORT_3306_TCP_PROTO=tcp
SYSTEM_MYSQL_SERVICE_PORT=3306
SYSTEM_PROVIDER_PORT=tcp://172.30.174.35:3000
SYSTEM_REDIS_PORT_6379_TCP_PORT=6379
SYSTEM_MEMCACHE_SERVICE_PORT=11211
SYSTEM_MEMCACHE_PORT_11211_TCP_ADDR=172.30.115.154
SYSTEM_SEARCHD_PORT=tcp://172.30.210.149:9306
SYSTEM_SEARCHD_PORT_9306_TCP_PORT=9306
SYSTEM_MEMCACHE_SERVICE_HOST=172.30.115.154
SYSTEM_SEARCHD_SERVICE_PORT_SEARCHD=9306
SYSTEM_MEMCACHE_PORT=tcp://172.30.115.154:11211
SYSTEM_SEARCHD_PORT_9306_TCP_PROTO=tcp
SYSTEM_MEMCACHE_PORT_11211_TCP_PORT=11211
SYSTEM_PROVIDER_PORT_3000_TCP_PROTO=tcp
SYSTEM_REDIS_PORT_6379_TCP_PROTO=tcp
SYSTEM_PROVIDER_PORT_3000_TCP_ADDR=172.30.174.35
```

After startup with services commented out the developer portal shows maintenance page: 
<img width="960" height="250" alt="image" src="https://github.com/user-attachments/assets/d2b0e8c6-a98a-40d3-bf72-08127de8364d" />.


The page starts to serve the developer portal once the service is created later without any action needed on Zync end. 


