### PR TITLE
THREESCALE-14473: Upgrade rack to 2.2.23 [2.16 backport]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,7 +241,7 @@ GEM
       que (>= 1)
       sinatra
     racc (1.8.1)
-    rack (2.2.20)
+    rack (2.2.23)
     rack-protection (2.2.3)
       rack
     rack-test (2.1.0)


### PR DESCRIPTION
Upgrade `rack` to `2.2.23`, fixes the following CVE:
- CVE-2026-34829 3scale-amp2/zync-rhel9: Rack: Denial of Service via unbounded multipart file upload [3amp-2.16]
- CVE-2026-22860 3scale-amp2/zync-rhel9: Rack Directory Traversal via Rack:Directory [3amp-2.16]

Fixes issues:
- https://redhat.atlassian.net/browse/THREESCALE-14473
- https://redhat.atlassian.net/browse/THREESCALE-14481