### PR TITLE
THREESCALE-12122: Fix Que worker connection to TLS protected DB [2.16 backport]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,44 @@
 version: 2.1
+
+commands:
+  bundle_install:
+    steps:
+      - run:
+          name: bundle install
+          command: |
+            bundle config set --local force_ruby_platform true
+            bundle config set --local deployment 'true'
+            bundle config set --local path 'vendor/bundle'
+            bundle install --jobs $(grep -c processor /proc/cpuinfo) --retry 3
+
+  boot_zync:
+    steps:
+      - run:
+          name: boot zync
+          command: |
+            BUNDLE_WITHOUT=development:test bundle exec bin/rails runner --environment=production 'puts Rails.env'
+
+  setup_db:
+    steps:
+      - run:
+          name: Set up the DB
+          command: |
+            bundle exec bin/rails db:wait db:setup
+
+  run_tests:
+    steps:
+      - run:
+          name: rails test
+          command: |
+            circleci tests glob "test/**/*_test.rb" | circleci tests run --command="xargs bundle exec rake test TESTOPTS='-v'" --verbose --split-by=timings
+
+  run_license_finder:
+    steps:
+      - run:
+          name: license_finder
+          command: |
+            bundle exec license_finder
+
 jobs:
   docker-build:
     resource_class: small
@@ -12,6 +52,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: zync
           RAILS_ENV: production
+          SECRET_KEY_BASE: test
     steps:
       - checkout
       - setup_remote_docker
@@ -20,8 +61,8 @@ jobs:
       - run: docker build --tag zync:build --file ./Dockerfile .
       - run:
           command: |
-            docker run --net net0 -e RAILS_ENV=${RAILS_ENV} -e DATABASE_URL=${DATABASE_URL} \
-            zync:build rails db:setup
+            docker run --net net0 -e RAILS_ENV=${RAILS_ENV} -e DATABASE_URL=${DATABASE_URL} -e SECRET_KEY_BASE=${SECRET_KEY_BASE} \
+            zync:build bundle exec rails db:setup
 
   build:
     parameters:
@@ -36,51 +77,98 @@ jobs:
         RAILS_ENV: test
         DISABLE_SPRING: 1 # we can't really run spring as it hangs on local circleci build
         DATABASE_URL: postgres://postgres:@localhost/circle_test
+        SECRET_KEY_BASE: test
     steps:
       - checkout
-
-      # Restore bundle cache
       - restore_cache:
           keys:
             - zync-bundle-v2-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Gemfile.lock" }}
-
-      - run:
-          name: bundle install
-          command: |
-            gem install bundler --version=$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tr -d ' '| tail -n 1) --no-document
-            bundle config --local force_ruby_platform true
-            bundle config set --local deployment 'true'
-            bundle config set --local path 'vendor/bundle'
-            bundle install --jobs $(grep -c processor /proc/cpuinfo) --retry 3
-      - run:
-          name: boot zync
-          command: BUNDLE_WITHOUT=development:test bundle exec bin/rails runner --environment=production 'puts Rails.env'
-
+      - bundle_install
       - save_cache:
           key: zync-bundle-v2-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
-
-      - run:
-          name: Set up the DB
-          command: bundle exec bin/rails db:wait db:setup
-
-      - run:
-          name: rails test
-          command: |
-            circleci tests glob "test/**/*_test.rb" | circleci tests run --command="xargs bundle exec rake test TESTOPTS='-v'" --verbose --split-by=timings
-      - run:
-          name: license_finder
-          command: |
-            bundle exec license_finder
-
+      - boot_zync
+      - setup_db
+      - run_tests
+      - run_license_finder
       - store_test_results:
           path: test/reports
 
+  build_ssl:
+    parameters:
+      postgresql_image:
+        type: string
+    working_directory: /opt/app-root/zync
+    docker:
+      - image: quay.io/3scale/zync:ci-builder
+      - image: << parameters.postgresql_image >>
+        command:
+          - bash
+          - -c
+          - |
+            openssl req -nodes -new -x509 -subj "/CN=localhost" -keyout /server.key -out /server.crt -days 365 2>/dev/null
+            chown postgres:postgres /server.key /server.crt
+            chmod 600 /server.key
+            # Configure pg_hba.conf to only allow SSL connections (hostssl instead of host)
+            # local rule is needed for postgres internal initialization via unix socket
+            echo "local all all trust" > /tmp/pg_hba.conf
+            echo "hostssl all all all trust" >> /tmp/pg_hba.conf
+            exec docker-entrypoint.sh postgres -c ssl=on -c ssl_cert_file=/server.crt -c ssl_key_file=/server.key -c hba_file=/tmp/pg_hba.conf
+        environment:
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_DB: circle_test
+    environment:
+        RAILS_ENV: test
+        DISABLE_SPRING: 1
+        DATABASE_URL: postgres://postgres:@localhost/circle_test
+        DATABASE_SSL_MODE: verify-full
+        SECRET_KEY_BASE: test
+    steps:
+      - checkout
+      - run:
+          name: Wait for PostgreSQL to be ready
+          command: |
+            for i in $(seq 1 30); do
+              if openssl s_client -starttls postgres -connect localhost:5432 </dev/null 2>&1 | grep -q "SSL handshake"; then
+                echo "PostgreSQL SSL is ready"
+                exit 0
+              fi
+              echo "Waiting for PostgreSQL SSL... ($i/30)"
+              sleep 1
+            done
+            echo "PostgreSQL failed to start with SSL"
+            exit 1
+      - run:
+          name: Extract server CA certificate and generate client certificate
+          command: |
+            mkdir -p .ssl
+            # Extract the server certificate (CA) using openssl s_client
+            openssl s_client -starttls postgres -connect localhost:5432 -showcerts </dev/null 2>/dev/null \
+              | openssl x509 -outform PEM > .ssl/ca.crt
+            # Generate client key and certificate (self-signed, PostgreSQL doesn't verify client certs by default)
+            openssl req -nodes -new -x509 -subj "/CN=postgres" -keyout .ssl/client.key -out .ssl/client.crt -days 365 2>/dev/null
+            chmod 600 .ssl/client.key
+      - run:
+          name: Set SSL environment variables
+          command: |
+            echo 'export DATABASE_SSL_CA=/opt/app-root/zync/.ssl/ca.crt' >> "$BASH_ENV"
+            echo 'export DATABASE_SSL_CERT=/opt/app-root/zync/.ssl/client.crt' >> "$BASH_ENV"
+            echo 'export DATABASE_SSL_KEY=/opt/app-root/zync/.ssl/client.key' >> "$BASH_ENV"
+      - restore_cache:
+          keys:
+            - zync-bundle-v2-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Gemfile.lock" }}
+      - bundle_install
       - save_cache:
-          key: zync-branch-v2-{{ arch }}-{{ .Branch }}
+          key: zync-bundle-v2-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
+      - boot_zync
+      - setup_db
+      - run_tests
+      - run_license_finder
+      - store_test_results:
+          path: test/reports
 
 workflows:
   version: 2.1
@@ -89,5 +177,9 @@ workflows:
       - build:
           matrix:
             parameters:
-              postgresql_image: [ "cimg/postgres:10.22", "cimg/postgres:12.15", "cimg/postgres:13.11", "cimg/postgres:14.12" ]
+              postgresql_image: [ "cimg/postgres:14.19", "cimg/postgres:15.14", "cimg/postgres:16.10", "cimg/postgres:17.6", "cimg/postgres:18.0" ]
+      - build_ssl:
+          matrix:
+            parameters:
+              postgresql_image: [ "cimg/postgres:14.19", "cimg/postgres:15.14", "cimg/postgres:16.10", "cimg/postgres:17.6", "cimg/postgres:18.0" ]
       - docker-build

--- a/config/initializers/que.rb
+++ b/config/initializers/que.rb
@@ -15,10 +15,17 @@ end
 
 def Que.start!
   require 'que/locker'
+  require 'que/db_connection_url'
 
   # Workaround for https://github.com/chanks/que/pull/192
   require 'active_record/base'
-  Que.locker = Que::Locker.new(**Rails.application.config.x.que)
+
+  # Build connection URL with SSL parameters from database config
+  # Workaround for https://github.com/que-rb/que/issues/442
+  db_config = ActiveRecord::Base.connection_db_config.configuration_hash
+  connection_url = Que::DBConnectionURL.build_connection_url(db_config)
+
+  Que.locker = Que::Locker.new(connection_url: connection_url, **Rails.application.config.x.que)
 end
 
 def Que.stop!

--- a/lib/que/db_connection_url.rb
+++ b/lib/que/db_connection_url.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Que
+  class DBConnectionURL
+    def self.build_connection_url(db_config)
+      # Build base URL
+      # Workaround for https://github.com/que-rb/que/issues/442
+      connection_url = "#{db_config[:adapter]}://"
+
+      host = db_config[:host]
+      is_unix_socket = host && host.start_with?('/')
+      is_ipv6 = host && !is_unix_socket && host.include?(':')
+
+      # Add username and password
+      connection_url += "#{db_config[:username]}" if db_config[:username]
+      connection_url += ":#{db_config[:password]}" if db_config[:password]
+      connection_url += "@" if db_config[:username] || db_config[:password]
+
+      # For Unix sockets, leave host empty; for TCP, add host and port
+      if is_unix_socket
+        connection_url += "/"
+      else
+        # Wrap IPv6 addresses in square brackets
+        formatted_host = is_ipv6 ? "[#{host}]" : (host || 'localhost')
+        connection_url += formatted_host
+        connection_url += ":#{db_config[:port]}" if db_config[:port]
+        connection_url += "/"
+      end
+
+      connection_url += db_config[:database]
+
+      # Build query parameters
+      params = []
+
+      # For Unix sockets, add host and port as query parameters
+      if is_unix_socket
+        params << "host=#{host}"
+        params << "port=#{db_config[:port]}" if db_config[:port]
+      end
+
+      # Add SSL parameters
+      params << "sslmode=#{db_config[:sslmode]}" if db_config[:sslmode]
+      params << "sslrootcert=#{db_config[:sslrootcert]}" if db_config[:sslrootcert]
+      params << "sslcert=#{db_config[:sslcert]}" if db_config[:sslcert]
+      params << "sslkey=#{db_config[:sslkey]}" if db_config[:sslkey]
+
+      connection_url += "?#{params.join('&')}" if params.any?
+
+      connection_url
+    end
+  end
+end

--- a/lib/tasks/que.rake
+++ b/lib/tasks/que.rake
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
+require 'que/db_connection_url'
+
 task que: 'que:exec'
 
 namespace :que do
   desc 'Start que worker'
   task exec: :environment do |_, args|
-    exec("que ./config/environment.rb que/prometheus #{args.extras.join}")
+    # Build base URL
+    # Workaround for https://github.com/que-rb/que/issues/442
+    db_config = ActiveRecord::Base.connection_db_config.configuration_hash
+    connection_url = Que::DBConnectionURL.build_connection_url(db_config)
+
+    exec("que --connection-url '#{connection_url}' ./config/environment.rb que/prometheus #{args.extras.join}")
   end
 
   desc 'Reschedule all jobs to be executed now'
@@ -20,3 +27,4 @@ namespace :que do
     Model.find_each(&UpdateJob.method(:perform_later))
   end
 end
+

--- a/test/lib/que/db_connection_url_test.rb
+++ b/test/lib/que/db_connection_url_test.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'que/db_connection_url'
+
+class Que::DBConnectionURLTest < ActiveSupport::TestCase
+  test 'minimal configuration' do
+    db_config = {
+      adapter: 'postgresql',
+      database: 'postgres'
+    }
+
+    expected = 'postgresql://localhost/postgres'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'connection with port' do
+    db_config = {
+      adapter: 'postgresql',
+      host: 'localhost',
+      port: 5432,
+      database: 'mydb'
+    }
+
+    expected = 'postgresql://localhost:5432/mydb'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'connection with username only' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'user',
+      host: 'localhost',
+      database: 'mydb'
+    }
+
+    expected = 'postgresql://user@localhost/mydb'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'connection with empty password' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'user',
+      password: '',
+      host: 'localhost',
+      database: 'mydb'
+    }
+
+    expected = 'postgresql://user:@localhost/mydb'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'connection with username and password' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'user',
+      password: 'secret',
+      host: 'localhost',
+      database: 'database'
+    }
+
+    expected = 'postgresql://user:secret@localhost/database'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'connection with password containing special characters' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'user',
+      password: 'p@ssw0rd!#$',
+      host: 'localhost',
+      database: 'mydb'
+    }
+
+    expected = 'postgresql://user:p@ssw0rd!#$@localhost/mydb'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'full connection with all basic parameters' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'user',
+      password: 'password',
+      host: 'localhost',
+      port: 5432,
+      database: 'database'
+    }
+
+    expected = 'postgresql://user:password@localhost:5432/database'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'connection with different host' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'username',
+      host: 'hostname',
+      database: 'databasename'
+    }
+
+    expected = 'postgresql://username@hostname/databasename'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'connection with SSL root certificate only' do
+    db_config = {
+      adapter: 'postgresql',
+      host: 'localhost',
+      database: 'mydb',
+      sslrootcert: '/etc/ssl/certs/ca.crt'
+    }
+
+    expected = 'postgresql://localhost/mydb?sslrootcert=/etc/ssl/certs/ca.crt'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'connection with SSL client certificate without mode' do
+    db_config = {
+      adapter: 'postgresql',
+      host: 'localhost',
+      database: 'mydb',
+      sslcert: '/path/to/cert.crt',
+      sslkey: '/path/to/key.key'
+    }
+
+    expected = 'postgresql://localhost/mydb?sslcert=/path/to/cert.crt&sslkey=/path/to/key.key'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'connection with all SSL parameters (mTLS)' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'user',
+      password: 'password',
+      host: 'host',
+      port: 5432,
+      database: 'database',
+      sslmode: 'verify-full',
+      sslrootcert: '/ca.crt',
+      sslcert: '/client.crt',
+      sslkey: '/client.key'
+    }
+
+    expected = 'postgresql://user:password@host:5432/database?sslmode=verify-full&sslrootcert=/ca.crt&sslcert=/client.crt&sslkey=/client.key'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'connection with IPv6 host' do
+    db_config = {
+      adapter: 'postgresql',
+      host: '::1',
+      database: 'database'
+    }
+
+    expected = 'postgresql://[::1]/database'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'connection with IPv6 host and port' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'user',
+      host: '2001:db8::1234',
+      port: 5433,
+      database: 'database'
+    }
+
+    expected = 'postgresql://user@[2001:db8::1234]:5433/database'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'connection with alternative adapter name' do
+    db_config = {
+      adapter: 'postgres',
+      host: 'localhost',
+      database: 'mydb'
+    }
+
+    expected = 'postgres://localhost/mydb'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'connection with database name containing underscores' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'postgres',
+      password: 'secret',
+      host: 'localhost',
+      database: 'test_db'
+    }
+
+    expected = 'postgresql://postgres:secret@localhost/test_db'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'production-like configuration with SSL' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'app_user',
+      password: 'secure_password',
+      host: 'db.example.com',
+      port: 5432,
+      database: 'production_db',
+      sslmode: 'verify-full',
+      sslrootcert: '/etc/ssl/certs/server-ca.pem',
+      sslcert: '/etc/ssl/certs/client-cert.pem',
+      sslkey: '/etc/ssl/private/client-key.pem'
+    }
+
+    expected = 'postgresql://app_user:secure_password@db.example.com:5432/production_db?sslmode=verify-full&sslrootcert=/etc/ssl/certs/server-ca.pem&sslcert=/etc/ssl/certs/client-cert.pem&sslkey=/etc/ssl/private/client-key.pem'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'OpenShift-like configuration' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'zync',
+      password: 'zync-password',
+      host: 'postgresql.example.svc.cluster.local',
+      port: 5432,
+      database: 'zync_production',
+      sslmode: 'require',
+      sslrootcert: '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'
+    }
+
+    expected = 'postgresql://zync:zync-password@postgresql.example.svc.cluster.local:5432/zync_production?sslmode=require&sslrootcert=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  # Unix socket connections
+  test 'Unix socket with default socket directory' do
+    db_config = {
+      adapter: 'postgresql',
+      database: 'mydb',
+      host: '/var/run/postgresql'
+    }
+
+    expected = 'postgresql:///mydb?host=/var/run/postgresql'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'Unix socket with username' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'user',
+      database: 'mydb',
+      host: '/var/run/postgresql'
+    }
+
+    expected = 'postgresql://user@/mydb?host=/var/run/postgresql'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'Unix socket with username and password' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'user',
+      password: 'password',
+      database: 'mydb',
+      host: '/var/run/postgresql'
+    }
+
+    expected = 'postgresql://user:password@/mydb?host=/var/run/postgresql'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'Unix socket with custom socket directory' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'postgres',
+      database: 'development',
+      host: '/opt/postgresql/run'
+    }
+
+    expected = 'postgresql://postgres@/development?host=/opt/postgresql/run'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'Unix socket with port parameter' do
+    db_config = {
+      adapter: 'postgresql',
+      database: 'mydb',
+      host: '/var/run/postgresql',
+      port: 5433
+    }
+
+    expected = 'postgresql:///mydb?host=/var/run/postgresql&port=5433'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'Unix socket with SSL parameters' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'user',
+      database: 'mydb',
+      host: '/var/run/postgresql',
+      sslmode: 'require'
+    }
+
+    expected = 'postgresql://user@/mydb?host=/var/run/postgresql&sslmode=require'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+
+  test 'Unix socket with all parameters' do
+    db_config = {
+      adapter: 'postgresql',
+      username: 'appuser',
+      password: 'secret',
+      database: 'production_db',
+      host: '/var/run/postgresql',
+      port: 5432,
+    }
+
+    expected = 'postgresql://appuser:secret@/production_db?host=/var/run/postgresql&port=5432'
+    assert_equal expected, Que::DBConnectionURL.build_connection_url(db_config)
+  end
+end


### PR DESCRIPTION
Backport to 2.16 of:

- https://github.com/3scale/zync/pull/573
- https://github.com/3scale/zync/pull/576

No strictly necessary for 2.16, but it includes the changes to the pipeline so the SSL connection fixed in this PR is actually tested by the pipeline.