### PR TITLE
Upgrade postgres to version 15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9:9.6
+FROM registry.access.redhat.com/ubi9:9.7
 
 ENV RUBY_MAJOR_VERSION=3 \
     RUBY_MINOR_VERSION=3 \
@@ -7,8 +7,10 @@ ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}"
 
 USER root
 
-RUN dnf -y module enable ruby:${RUBY_VERSION} \
-    && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs -y shared-mime-info make automake gcc gcc-c++ postgresql git ruby-devel rubygem-irb rubygem-rdoc glibc-devel libpq-devel libyaml-devel xz \
+RUN dnf update --setopt=install_weak_deps=0 --setopt=tsflags=nodocs -y \
+    && dnf -y module enable ruby:${RUBY_VERSION} \
+    && dnf -y module enable postgresql:15 \
+    && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs -y shared-mime-info postgresql rubygem-irb rubygem-rdoc make automake gcc gcc-c++ git ruby-devel glibc-devel libpq-devel libxml2-devel libxslt-devel libyaml-devel xz \
     && dnf clean all \
     && rm -rf /var/cache/yum
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,15 @@
-FROM registry.access.redhat.com/ubi9:9.7
+FROM registry.access.redhat.com/ubi10:10.1
 
-ENV RUBY_MAJOR_VERSION=3 \
-    RUBY_MINOR_VERSION=3 \
-    APP_ROOT=/opt/app-root/src
-ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}"
+ENV APP_ROOT=/opt/app-root/src
 
 USER root
 
 RUN dnf update --setopt=install_weak_deps=0 --setopt=tsflags=nodocs -y \
-    && dnf -y module enable ruby:${RUBY_VERSION} \
-    && dnf -y module enable postgresql:15 \
     && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs -y shared-mime-info postgresql rubygem-irb rubygem-rdoc make automake gcc gcc-c++ git ruby-devel glibc-devel libpq-devel libxml2-devel libxslt-devel libyaml-devel xz \
     && dnf clean all \
     && rm -rf /var/cache/yum
 
-# Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2221938
-RUN ln -s /usr/share/gems/gems/rdoc-6.4.0/lib/rdoc.rb /usr/share/ruby/ \
-    ln -s /usr/share/gems/gems/rdoc-6.4.0/lib/rdoc /usr/share/ruby/
+RUN echo "Ruby version: " && ruby --version && echo "PostgreSQL version: " && psql --version
 
 RUN mkdir -p ${APP_ROOT} \
     && chown -R 1001:root ${APP_ROOT}


### PR DESCRIPTION
Apparently, version 13 was installed in the upstream images, and it didn't work with postgres v15.

The initial attempt was just to enable the module with the newer version, as we do it in midstream:
```
dnf -y module enable postgresql:15
```

However, it turns out that this module is not available in UBI9 repos, only in RHEL9 :(

So, I tried upgrading to UBI10 instead. Apparently, in UBI10 modules are not available anymore:
```
WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
```

But I verified that actually the `ruby` version is `3.3` (the one we need), and `postgresql` is `16.13`. It's one version above the one we support, but it seems that PG client can work fine with older server versions (not the other way around) - although I'm struggling to find official statement from PostgreSQL on this.
I hope this will work though for the upstream image - and also, this way we can easier upgrade to supporting PostgreSQL 16 :)