### PR TITLE
Set RAILS_ENV=production in upstream image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM registry.access.redhat.com/ubi9:9.6
 
 ENV RUBY_MAJOR_VERSION=3 \
     RUBY_MINOR_VERSION=3 \
+    RAILS_ENV=production \
     APP_ROOT=/opt/app-root/src
 ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}"
 


### PR DESCRIPTION
Apart from being conceptually more correct, it also fixes an issue with running the image (which has postgres 13 client libs) with a PostgreSQL 15 server:

```
pg_dump: error: server version: 15.14; pg_dump version: 13.23
pg_dump: error: aborting because of server version mismatch
bin/rails aborted!
failed to execute:
pg_dump --schema-only --no-privileges --no-owner --file /opt/app-root/src/db/structure.sql zync_development

Please check the output above for any errors and make sure that `pg_dump` is installed in your PATH and has proper permissions.
```

because production mode has:
```
  # Do not dump schema after migrations.
  config.active_record.dump_schema_after_migration = false
```

so, when running in production `pg_dump` is not called on `db:migrate`.