### PR TITLE
THREESCALE-12102-support-token-exchange

### DIFF
--- a/app/adapters/keycloak_adapter.rb
+++ b/app/adapters/keycloak_adapter.rb
@@ -19,6 +19,12 @@ class KeycloakAdapter < AbstractAdapter
       }.compact
     end
 
+    def token_exchange_attributes
+      token_exchange = params[:token_exchange_enabled]
+      return {} if token_exchange.nil?
+      { 'standard.token.exchange.enabled' => token_exchange.to_s }
+    end
+
     protected
 
     attr_reader :params
@@ -43,18 +49,19 @@ class KeycloakAdapter < AbstractAdapter
     delegate :to_json, to: :to_h
     alias read to_json
 
-    attribute :oidc_configuration, default: {}.freeze
+    attribute :oidc_configuration, default: -> { OAuthConfiguration.new({}) }
 
     def to_h
+      oidc = oidc_configuration
       {
           name: name,
           description: description,
           clientId: id,
           secret: client_secret,
           redirectUris: [ redirect_url ].compact,
-          attributes: { '3scale' => true },
+          attributes: { '3scale' => true }.merge(oidc.token_exchange_attributes),
           enabled: enabled?,
-          **oidc_configuration,
+          **oidc,
           **self.class.attributes,
       }
     end

--- a/app/adapters/rest_adapter.rb
+++ b/app/adapters/rest_adapter.rb
@@ -109,6 +109,7 @@ class RESTAdapter < AbstractAdapter
           implicit_flow_enabled: :implicit,
           direct_access_grants_enabled: :password,
           service_accounts_enabled: :client_credentials,
+          token_exchange_enabled: :"urn:ietf:params:oauth:grant-type:token-exchange",
       }.freeze
       private_constant :MAPPING
 

--- a/app/services/integration/abstract_service.rb
+++ b/app/services/integration/abstract_service.rb
@@ -95,6 +95,7 @@ class Integration::AbstractService < Integration::ServiceBase
 
   OIDC_FLOWS = %i[
     standard_flow_enabled implicit_flow_enabled service_accounts_enabled direct_access_grants_enabled
+    token_exchange_enabled
   ].freeze
   private_constant :OIDC_FLOWS
 

--- a/test/adapters/keycloak_adapter_test.rb
+++ b/test/adapters/keycloak_adapter_test.rb
@@ -113,4 +113,28 @@ class KeycloakAdapterTest < ActiveSupport::TestCase
                                                     }
                                                 }).to_h.slice(*keycloak.keys)
   end
+
+  test 'oauth flows with token exchange enabled' do
+    client = KeycloakAdapter::Client.new({
+      id: 'client_id',
+      oidc_configuration: {
+        token_exchange_enabled: true,
+      }
+    })
+    hash = client.to_h
+    assert_equal 'true', hash[:attributes]['standard.token.exchange.enabled']
+    assert_equal true, hash[:attributes]['3scale']
+  end
+
+  test 'oauth flows without token exchange preserves 3scale attribute' do
+    client = KeycloakAdapter::Client.new({
+      id: 'client_id',
+      oidc_configuration: {
+        standard_flow_enabled: true,
+      }
+    })
+    hash = client.to_h
+    assert_equal true, hash[:attributes]['3scale']
+    assert_nil hash[:attributes]['standard.token.exchange.enabled']
+  end
 end

--- a/test/adapters/keycloak_adapter_test.rb
+++ b/test/adapters/keycloak_adapter_test.rb
@@ -105,23 +105,16 @@ class KeycloakAdapterTest < ActiveSupport::TestCase
   test 'oauth flows' do
     keycloak = { clientId: "client_id", implicitFlowEnabled: true, serviceAccountsEnabled: true }
 
-    assert_equal keycloak, KeycloakAdapter::Client.new({
-                                                    id: 'client_id',
-                                                    oidc_configuration: {
-                                                        implicit_flow_enabled: true,
-                                                        service_accounts_enabled: true,
-                                                    }
-                                                }).to_h.slice(*keycloak.keys)
-  end
-
-  test 'oauth flows with token exchange enabled' do
     client = KeycloakAdapter::Client.new({
       id: 'client_id',
       oidc_configuration: {
+        implicit_flow_enabled: true,
+        service_accounts_enabled: true,
         token_exchange_enabled: true,
       }
     })
     hash = client.to_h
+    assert_equal keycloak, hash.slice(*keycloak.keys)
     assert_equal 'true', hash[:attributes]['standard.token.exchange.enabled']
     assert_equal true, hash[:attributes]['3scale']
   end
@@ -136,5 +129,37 @@ class KeycloakAdapterTest < ActiveSupport::TestCase
     hash = client.to_h
     assert_equal true, hash[:attributes]['3scale']
     assert_nil hash[:attributes]['standard.token.exchange.enabled']
+  end
+
+  test 'oauth flows with token exchange disabled' do
+    client = KeycloakAdapter::Client.new({
+      id: 'client_id',
+      oidc_configuration: {
+        token_exchange_enabled: false,
+      }
+    })
+    hash = client.to_h
+    assert_equal 'false', hash[:attributes]['standard.token.exchange.enabled']
+    assert_equal true, hash[:attributes]['3scale']
+  end
+
+  test 'create client with token exchange' do
+    keycloak = KeycloakAdapter.new('http://example.com/auth/realm/name', authentication: 'sometoken')
+
+    client = KeycloakAdapter::Client.new({
+      id: 'client_id',
+      oidc_configuration: { token_exchange_enabled: true }
+    })
+
+    create = stub_request(:post, 'http://example.com/auth/realm/name/clients-registrations/default').
+        with(
+            body: client.to_json,
+            headers: { 'Content-Type' => 'application/json', 'Authorization' => 'Bearer sometoken' }).
+        to_return(status: 200, body: { clientId: 'client_id' }.to_json,
+                  headers: { 'Content-Type' => 'application/json' })
+
+    keycloak.create_client(client)
+
+    assert_requested create
   end
 end

--- a/test/adapters/rest_adapter_test.rb
+++ b/test/adapters/rest_adapter_test.rb
@@ -72,6 +72,27 @@ class RESTAdapterTest < ActiveSupport::TestCase
     refute_includes grant_types, 'urn:ietf:params:oauth:grant-type:token-exchange'
   end
 
+  test 'create client with token exchange sends grant type' do
+    client = RESTAdapter::Client.new(
+      id: 'foo',
+      oidc_configuration: {
+        standard_flow_enabled: true,
+        token_exchange_enabled: true,
+      }
+    )
+
+    stub_request(:get, "https://example.com/.well-known/openid-configuration").
+      to_return(status: 404, body: '', headers: {})
+
+    stub_request(:put, "https://example.com/clients/foo").
+      with(
+        body: client.to_json,
+        headers: { 'Content-Type'=>'application/json' }).
+      to_return(status: 200, body: { status: 'ok' }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    assert subject.new('https://example.com').create_client(client)
+  end
+
   test 'create client with basic auth' do
     client = RESTAdapter::Client.new(id: 'foo')
     adapter = subject.new('https://user:pass@example.com')

--- a/test/adapters/rest_adapter_test.rb
+++ b/test/adapters/rest_adapter_test.rb
@@ -46,6 +46,32 @@ class RESTAdapterTest < ActiveSupport::TestCase
     assert subject.new('https://example.com').create_client(client)
   end
 
+  test 'oauth flows with token exchange' do
+    client = RESTAdapter::Client.new(
+      id: 'foo',
+      oidc_configuration: {
+        standard_flow_enabled: true,
+        token_exchange_enabled: true,
+      }
+    )
+    grant_types = JSON.parse(client.to_json).fetch('grant_types')
+    assert_includes grant_types, 'authorization_code'
+    assert_includes grant_types, 'urn:ietf:params:oauth:grant-type:token-exchange'
+  end
+
+  test 'oauth flows without token exchange' do
+    client = RESTAdapter::Client.new(
+      id: 'foo',
+      oidc_configuration: {
+        standard_flow_enabled: true,
+        token_exchange_enabled: false,
+      }
+    )
+    grant_types = JSON.parse(client.to_json).fetch('grant_types')
+    assert_includes grant_types, 'authorization_code'
+    refute_includes grant_types, 'urn:ietf:params:oauth:grant-type:token-exchange'
+  end
+
   test 'create client with basic auth' do
     client = RESTAdapter::Client.new(id: 'foo')
     adapter = subject.new('https://user:pass@example.com')


### PR DESCRIPTION
**What this PR does / why we need it:**

Maps the token_exchange_enabled OIDC flow from Porta to the Keycloak client attribute standard.token.exchange.enabled, enabling RHBK Standard Token Exchange (V2) on synced clients.

Unlike the other OIDC flows (standardFlowEnabled, implicitFlowEnabled, etc.) which are top-level Keycloak client fields, token exchange is controlled via the client attributes hash with key standard.token.exchange.enabled. This PR handles that difference in KeycloakAdapter::OAuthConfiguration.

Also adds the urn:ietf:params:oauth:grant-type:token-exchange grant type mapping in RESTAdapter::GrantTypes for non-Keycloak OIDC providers that follow RFC 8693.

**Ticket requirements (THREESCALE-12102):**

1. Add native support in APIcast for validating OBO tokens: (Verified). APIcast validates OBO tokens out of the box since they are standard JWTs. Tested by obtaining an OBO token via Keycloak token exchange and
sending it through APIcast, returned HTTP 200.

2. Ensure compatibility with RHBK Standard Token Exchange (V2): Companion Porta PR adds the UI/API toggle. This Zync PR maps it to Keycloak's standard.token.exchange.enabled attribute. Verified end-to-end: toggle
ON in Porta → Keycloak client shows standard.token.exchange.enabled: "true", toggle OFF → shows "false", toggle ON again → shows "true".

3. Provide configuration options to enforce policies based on both client and user claims: (Verified). The OBO token contains both client claims (azp, client_id) and user claims (sub, preferred_username, email,
roles). APIcast extracts the client identity via jwt_claim_with_client_id (mapped to azp) for rate limiting, and existing policies like keycloak_role_check can enforce rules on user roles. Tested with an unknown
client azp → APIcast returned HTTP 403.

**Which issue(s) this PR fixes**

https://redhat.atlassian.net/browse/THREESCALE-12102

**Verification steps**

1. Enable token_exchange_enabled on a service in Porta
2. Verify the Keycloak client has standard.token.exchange.enabled: "true" in its attributes
3. Verify the 3scale: true attribute is preserved alongside token exchange
4. Disable token_exchange_enabled and verify the attribute is set to "false"
5. Run tests: bundle exec rails test test/adapters/keycloak_adapter_test.rb test/adapters/rest_adapter_test.rb

**Note**: End-to-end testing (Porta → Zync → Keycloak → APIcast) was done by temporarily cherry-picking commits from PR #4310 (OIDC sync token rotation). Will re-test after #4310 is merged.