### PR TITLE
Add redhat-rpm-config package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}"
 USER root
 
 RUN dnf -y module enable ruby:${RUBY_VERSION} \
-    && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs -y shared-mime-info make automake gcc gcc-c++ postgresql git ruby-devel rubygem-irb rubygem-rdoc glibc-devel libpq-devel libyaml-devel xz \
+    && dnf install --setopt=skip_missing_names_on_install=False,tsflags=nodocs -y shared-mime-info make automake gcc gcc-c++ redhat-rpm-config postgresql git ruby-devel rubygem-irb rubygem-rdoc glibc-devel libpq-devel libyaml-devel xz \
     && dnf clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
Fix Docker builds, `bundle install` was failing with:

```
LD_LIBRARY_PATH=.:/usr/lib64 "gcc -o conftest -I/usr/include -I/usr/include/ruby/backward -I/usr/include -I.    -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -march=x86-64-v2 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fPIC conftest.c  -L. -L/usr/lib64 -L. -Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fstack-protector-strong -rdynamic -Wl,-export-dynamic -Wl,--no-as-needed  -m64   -lruby  -lm -lpthread  -lc"
gcc: fatal error: cannot read spec file '/usr/lib/rpm/redhat/redhat-hardened-cc1': No such file or directory
compilation terminated.
```