### PR TITLE
THREESCALE-15279: Add an "audience" protocol mapper to Keycloak integration

### DIFF
--- a/app/adapters/keycloak_adapter.rb
+++ b/app/adapters/keycloak_adapter.rb
@@ -34,7 +34,8 @@ class KeycloakAdapter < AbstractAdapter
     # noinspection RubyResolve
     # ActiveModel::AttributeAssignment needs public accessors breaking :reek:Attribute
     attr_accessor :id, :secret, :redirect_url,
-                  :state, :enabled, :name, :description
+                  :state, :enabled, :name, :description,
+                  :audience_mapper_client_id
 
     alias_attribute :clientId, :id
     alias_attribute :client_id, :id
@@ -54,6 +55,7 @@ class KeycloakAdapter < AbstractAdapter
           redirectUris: [ redirect_url ].compact,
           attributes: { '3scale' => true },
           enabled: enabled?,
+          **(audience_mapper? ? { protocolMappers: [audience_mapper] } : {}),
           **oidc_configuration,
           **self.class.attributes,
       }
@@ -78,6 +80,26 @@ class KeycloakAdapter < AbstractAdapter
 
     def self.attributes
       Rails.application.config.x.keycloak.deep_symbolize_keys.dig(:attributes) || Hash.new
+    end
+
+    private
+
+    def audience_mapper?
+      audience_mapper_client_id.present? &&
+        !Rails.application.config.x.keycloak.deep_symbolize_keys.dig(:client_audience_mapper_disabled)
+    end
+
+    def audience_mapper
+      {
+        name: 'audience-mapper',
+        protocol: 'openid-connect',
+        protocolMapper: 'oidc-audience-mapper',
+        config: {
+          'included.client.audience' => audience_mapper_client_id,
+          'id.token.claim' => 'false',
+          'access.token.claim' => 'true',
+        },
+      }
     end
   end
 

--- a/app/services/integration/abstract_service.rb
+++ b/app/services/integration/abstract_service.rb
@@ -102,6 +102,7 @@ class Integration::AbstractService < Integration::ServiceBase
     params = ActionController::Parameters.new(data)
     params.permit(:client_id, :client_secret, :redirect_url,
                   :state, :enabled, :name, :description,
+                  :audience_mapper_client_id,
                   oidc_configuration: OIDC_FLOWS)
   end
 

--- a/config/keycloak.yml
+++ b/config/keycloak.yml
@@ -1,4 +1,13 @@
 example:
+  # Disable the audience mapper added to Keycloak clients. The mapper is
+  # required for token introspection on RHBK 26.6.2+. When enabled, the
+  # 'oidc-audience-mapper' type must be allowed for client registration:
+  # Keycloak: Realm Settings -> Client Registration -> Client Registration Policies
+  # RHBK: Clients -> Client Registration
+  # In both cases, add oidc-audience-mapper to the Allowed Protocol Mapper Types
+  # policy for both Anonymous and Authenticated clients.
+  # Set ZYNC_CLIENT_AUDIENCE_MAPPER_DISABLED=1 to disable.
+  client_audience_mapper_disabled: false
   attributes:
     # see other properties in https://www.keycloak.org/docs-api/3.4/javadocs/org/keycloak/representations/idm/ClientTemplateRepresentation.html
     standardFlowEnabled: true
@@ -11,6 +20,7 @@ default: &default
     connect_timeout: 3
     send_timeout: 3
     receive_timeout: 3
+  client_audience_mapper_disabled: <%= ENV.fetch('ZYNC_CLIENT_AUDIENCE_MAPPER_DISABLED', '0') == '1' %>
 
 development:
 

--- a/test/adapters/keycloak_adapter_test.rb
+++ b/test/adapters/keycloak_adapter_test.rb
@@ -102,6 +102,43 @@ class KeycloakAdapterTest < ActiveSupport::TestCase
     assert_equal client.to_h.to_json, client.to_json
   end
 
+  test 'audience mapper included when audience_mapper_client_id is set' do
+    config = { 'client_audience_mapper_disabled' => false }
+
+    Rails.application.config.x.stub(:keycloak, config) do
+      client = KeycloakAdapter::Client.new(id: 'my-client-id', audience_mapper_client_id: 'introspection-client')
+      mappers = client.to_h[:protocolMappers]
+
+      assert_equal 1, mappers.length
+      mapper = mappers.first
+      assert_equal 'audience-mapper', mapper[:name]
+      assert_equal 'oidc-audience-mapper', mapper[:protocolMapper]
+      assert_equal 'introspection-client', mapper[:config]['included.client.audience']
+      assert_equal 'true', mapper[:config]['access.token.claim']
+      assert_equal 'false', mapper[:config]['id.token.claim']
+    end
+  end
+
+  test 'audience mapper omitted when audience_mapper_client_id is absent' do
+    config = { 'client_audience_mapper_disabled' => false }
+
+    Rails.application.config.x.stub(:keycloak, config) do
+      client = KeycloakAdapter::Client.new(id: 'my-client-id')
+
+      assert_nil client.to_h[:protocolMappers]
+    end
+  end
+
+  test 'audience mapper omitted when globally disabled regardless of audience_mapper_client_id' do
+    config = { 'client_audience_mapper_disabled' => true }
+
+    Rails.application.config.x.stub(:keycloak, config) do
+      client = KeycloakAdapter::Client.new(id: 'my-client-id', audience_mapper_client_id: 'introspection-client')
+
+      assert_nil client.to_h[:protocolMappers]
+    end
+  end
+
   test 'oauth flows' do
     keycloak = { clientId: "client_id", implicitFlowEnabled: true, serviceAccountsEnabled: true }
 

--- a/test/fixtures/entries.yml
+++ b/test/fixtures/entries.yml
@@ -16,6 +16,7 @@ client:
     redirect_url: "http://example.com"
     client_id: "two_id"
     client_secret: "two_secret"
+    audience_mapper_client_id: "two_id"
     oidc_configuration:
       standard_flow_enabled: true
       implicit_flow_enabled: true

--- a/test/integration/data_model_test.rb
+++ b/test/integration/data_model_test.rb
@@ -79,7 +79,7 @@ class DataModelTest < ActionDispatch::IntegrationTest
         params: { type: 'Application', id: 1, service_id: 1, tenant_id: 1 }
     assert_response :success
 
-    client = { client_id: 'foo', client_secret: 'bar' }
+    client = { client_id: 'foo', client_secret: 'bar', audience_mapper_client_id: 'foo' }
     find_application = stub_request(:get, "#{tenant[:endpoint]}/admin/api/applications/find.json?application_id=1").
         with(headers: http_fetch_headers).
         to_return(body: client.to_json)
@@ -91,9 +91,11 @@ class DataModelTest < ActionDispatch::IntegrationTest
         to_return(status: 404)
 
     perform_enqueued_jobs do
+      audience_mapper_foo = [{ name: 'audience-mapper', protocol: 'openid-connect', protocolMapper: 'oidc-audience-mapper', config: { 'included.client.audience' => 'foo', 'id.token.claim' => 'false', 'access.token.claim' => 'true' } }]
+
       stub_request(:put, 'http://example.com/auth/realm/master/clients-registrations/default/foo').
           with(
-              body: '{"name":null,"description":null,"clientId":"foo","secret":"bar","redirectUris":[],"attributes":{"3scale":true},"enabled":null}',
+              body: { name: nil, description: nil, clientId: 'foo', secret: 'bar', redirectUris: [], attributes: { '3scale' => true }, enabled: nil, protocolMappers: audience_mapper_foo }.to_json,
               headers: {
                   'Authorization'=>'Bearer token',
                   'Content-Type'=>'application/json',
@@ -102,7 +104,7 @@ class DataModelTest < ActionDispatch::IntegrationTest
 
       stub_request(:put, 'http://example.com/auth/realm/master/clients-registrations/default/foo').
           with(
-              body: '{"name":"new-name","description":null,"clientId":"foo","secret":"bar","redirectUris":[],"attributes":{"3scale":true},"enabled":null}',
+              body: { name: 'new-name', description: nil, clientId: 'foo', secret: 'bar', redirectUris: [], attributes: { '3scale' => true }, enabled: nil, protocolMappers: audience_mapper_foo }.to_json,
               headers: {
                   'Authorization'=>'Bearer token',
                   'Content-Type'=>'application/json',
@@ -136,21 +138,23 @@ class DataModelTest < ActionDispatch::IntegrationTest
     perform_enqueued_jobs do
       stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?application_id=1").
           with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
-          to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar' }.to_json)
+          to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar', audience_mapper_client_id: 'foo' }.to_json)
 
       stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?app_id=foo&service_id=298486374").
           with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
-          to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar' }.to_json)
+          to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar', audience_mapper_client_id: 'foo' }.to_json)
 
       stub_oauth_access_token(keycloak)
 
+      audience_mapper_foo = [{ name: 'audience-mapper', protocol: 'openid-connect', protocolMapper: 'oidc-audience-mapper', config: { 'included.client.audience' => 'foo', 'id.token.claim' => 'false', 'access.token.claim' => 'true' } }]
+
       stub_request(:put, "http://example.com/clients-registrations/default/foo").
-        with(body: '{"name":null,"description":null,"clientId":"foo","secret":"bar","redirectUris":[],"attributes":{"3scale":true},"enabled":null}').
+        with(body: { name: nil, description: nil, clientId: 'foo', secret: 'bar', redirectUris: [], attributes: { '3scale' => true }, enabled: nil, protocolMappers: audience_mapper_foo }.to_json).
         to_return(status: 200)
 
       stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?application_id=2").
           with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
-          to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar' }.to_json)
+          to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar', audience_mapper_client_id: 'foo' }.to_json)
 
       put_notification(type: 'Application', id: 1, service_id: service.to_param, tenant_id: tenant.to_param)
       put_notification(type: 'Application', id: 2, service_id: service.to_param, tenant_id: tenant.to_param)
@@ -172,16 +176,18 @@ class DataModelTest < ActionDispatch::IntegrationTest
     perform_enqueued_jobs do
       stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?application_id=1").
         with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
-        to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar' }.to_json)
+        to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar', audience_mapper_client_id: 'foo' }.to_json)
 
       stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?app_id=foo&service_id=298486374").
         with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
-        to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar' }.to_json)
+        to_return(status: 200, body: { client_id: 'foo', client_secret: 'bar', audience_mapper_client_id: 'foo' }.to_json)
 
       stub_oauth_access_token(keycloak)
 
+      audience_mapper_foo = [{ name: 'audience-mapper', protocol: 'openid-connect', protocolMapper: 'oidc-audience-mapper', config: { 'included.client.audience' => 'foo', 'id.token.claim' => 'false', 'access.token.claim' => 'true' } }]
+
       stub_request(:put, "http://example.com/clients-registrations/default/foo").
-        with(body: '{"name":null,"description":null,"clientId":"foo","secret":"bar","redirectUris":[],"attributes":{"3scale":true},"enabled":null}').
+        with(body: { name: nil, description: nil, clientId: 'foo', secret: 'bar', redirectUris: [], attributes: { '3scale' => true }, enabled: nil, protocolMappers: audience_mapper_foo }.to_json).
         to_return(status: 200)
 
       put_notification(type: 'Application', id: 1, service_id: service.to_param, tenant_id: tenant.to_param)
@@ -223,26 +229,28 @@ class DataModelTest < ActionDispatch::IntegrationTest
     perform_enqueued_jobs do
       stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?application_id=1").
         with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
-        to_return(status: 200, body: { client_id: 'foo' }.to_json)
+        to_return(status: 200, body: { client_id: 'foo', audience_mapper_client_id: 'foo' }.to_json)
       stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?application_id=2").
         with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
-        to_return(status: 200, body: { client_id: 'foo' }.to_json)
+        to_return(status: 200, body: { client_id: 'foo', audience_mapper_client_id: 'foo' }.to_json)
 
       stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?app_id=foo&service_id=298486374").
         with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
-        to_return(status: 200, body: { client_id: 'foo', client_secret: 'secret-service-one' }.to_json)
+        to_return(status: 200, body: { client_id: 'foo', client_secret: 'secret-service-one', audience_mapper_client_id: 'foo' }.to_json)
       stub_request(:get, "#{tenant.endpoint}/admin/api/applications/find.json?app_id=foo&service_id=908005739").
         with(basic_auth: ['', tenant.access_token], headers: json_request_headers).
-        to_return(status: 200, body: { client_id: 'foo', client_secret: 'secret-service-two' }.to_json)
+        to_return(status: 200, body: { client_id: 'foo', client_secret: 'secret-service-two', audience_mapper_client_id: 'foo' }.to_json)
 
       stub_oauth_access_token(keycloak1)
       stub_oauth_access_token(keycloak2)
       
+      audience_mapper_foo = [{ name: 'audience-mapper', protocol: 'openid-connect', protocolMapper: 'oidc-audience-mapper', config: { 'included.client.audience' => 'foo', 'id.token.claim' => 'false', 'access.token.claim' => 'true' } }]
+
       stub_request(:put, "http://example.com/clients-registrations/default/foo").
-        with(body: '{"name":null,"description":null,"clientId":"foo","secret":"secret-service-one","redirectUris":[],"attributes":{"3scale":true},"enabled":null}').
+        with(body: { name: nil, description: nil, clientId: 'foo', secret: 'secret-service-one', redirectUris: [], attributes: { '3scale' => true }, enabled: nil, protocolMappers: audience_mapper_foo }.to_json).
         to_return(status: 200)
       stub_request(:put, "http://second.example.com/clients-registrations/default/foo").
-        with(body: '{"name":null,"description":null,"clientId":"foo","secret":"secret-service-two","redirectUris":[],"attributes":{"3scale":true},"enabled":null}').
+        with(body: { name: nil, description: nil, clientId: 'foo', secret: 'secret-service-two', redirectUris: [], attributes: { '3scale' => true }, enabled: nil, protocolMappers: audience_mapper_foo }.to_json).
         to_return(status: 200)
 
       put_notification(type: 'Application', id: 1, service_id: service1.to_param, tenant_id: tenant.to_param)

--- a/test/services/integration/keycloak_service_test.rb
+++ b/test/services/integration/keycloak_service_test.rb
@@ -36,16 +36,49 @@ class Integration::KeycloakServiceTest < ActiveSupport::TestCase
     end
   end
 
-  test 'client auth flows attributes' do
+  test 'client create sends audience mapper' do
     entry = entries(:client)
 
+    audience_mapper = [{ name: 'audience-mapper', protocol: 'openid-connect', protocolMapper: 'oidc-audience-mapper', config: { 'included.client.audience' => 'two_id', 'id.token.claim' => 'false', 'access.token.claim' => 'true' } }]
+
     stub_request(:put, "http://example.com/clients-registrations/default/two_id").
+      to_return(status: 404)
+
+    create_stub = stub_request(:post, "http://example.com/clients-registrations/default").
       with(
         body: {
             name: "client name", description: "client description",
             clientId: "two_id", secret: "two_secret",
             redirectUris: ["http://example.com"], attributes: {'3scale' => true},
             enabled: true,
+            protocolMappers: audience_mapper,
+            standardFlowEnabled: true, implicitFlowEnabled: true,
+            serviceAccountsEnabled: true, directAccessGrantsEnabled: true,
+        }.to_json,
+      ).to_return(status: 200, body: { clientId: 'two_id' }.to_json,
+                  headers: { 'Content-Type' => 'application/json' })
+
+    subject.tap do |service|
+      service.adapter.authentication = 'foobar'
+      service.call(entry)
+    end
+
+    assert_requested create_stub
+  end
+
+  test 'client update sends audience mapper' do
+    entry = entries(:client)
+
+    audience_mapper = [{ name: 'audience-mapper', protocol: 'openid-connect', protocolMapper: 'oidc-audience-mapper', config: { 'included.client.audience' => 'two_id', 'id.token.claim' => 'false', 'access.token.claim' => 'true' } }]
+
+    update_stub = stub_request(:put, "http://example.com/clients-registrations/default/two_id").
+      with(
+        body: {
+            name: "client name", description: "client description",
+            clientId: "two_id", secret: "two_secret",
+            redirectUris: ["http://example.com"], attributes: {'3scale' => true},
+            enabled: true,
+            protocolMappers: audience_mapper,
             standardFlowEnabled: true, implicitFlowEnabled: true,
             serviceAccountsEnabled: true, directAccessGrantsEnabled: true,
         }.to_json,
@@ -55,6 +88,8 @@ class Integration::KeycloakServiceTest < ActiveSupport::TestCase
       service.adapter.authentication = 'foobar'
       service.call(entry)
     end
+
+    assert_requested update_stub
   end
 
   protected


### PR DESCRIPTION
**Jira Issue:**

https://redhat.atlassian.net/browse/THREESCALE-15279

**Description:**

As the issue describes, after a breaking change in a recent RHBK release, the token introspection feature stopped working. In order to fix it, we need to ensure the access token received from keycloak includes the client id in the `aud` field.

Keycloak provides a way to write on this field, which is installing a protocol mapper type `oidc-audiende-mapper` in all clients.

This PR modifies the Keycloak integration in Zync to add such mapper in the requests to the client registration service in Keycloak.

**Verification steps:**

1. Ensure the server allows the `oidc-audience-mapper` for client registration
   - Keycloak: Realm Settings -> Client Registration -> Client Registration Policies
   - RHBK: Clients -> Client Registration
   - In both cases, add `oidc-audience-mapper` to the `Allowed Protocol Mapper Types` policy for both `Anonymous` and `Authenticated` clients
2. Sync an application from porta. The fastest way is to regenerate the client secret.
3. You should see the mapper in the server UI
   - Keycloak: Clients -> [client id] -> Mappers
   - RHBK: Clients -> [client id] -> Client Scopes -> [client id]-dedicated -> Mappers
4. Get an access token

```
ACCESS_TOKEN=`curl   -d "client_id=[client_id]"   -d "client_secret=[client_secret]"   -d "grant_type=client_credentials"   "[endpoint]/auth/realms/[realm]/protocol/openid-connect/token" | jq -r '.access_token'`
```

5. Get the introspection token

```
curl -X POST     [endpoint]/auth/realms/joan/protocol/openid-connect/token/introspect     -u "[client_id]:[client_secret]"     -d "token=$ACCESS_TOKEN"
```

6. You should get a valid token. If you get `{"active": false}` then it's not working.